### PR TITLE
add missing jq tool to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     curl \
     build-essential \
     git \
+    jq \
     wget \
     apt-transport-https \
     ca-certificates \


### PR DESCRIPTION
* needed by the [`build/download_binaries.sh`](https://github.com/portainer/portainer/blob/61642b8df610712c3cd71efc0e792c53627878d2/build/download_binaries.sh) script used by the `server-deps` target in the Makefile

Thanks for this dev-tools image, really saves a lot of time and effort!

EDIT: For more context, here is a demonstration of the issue without this PR:
```
$ docker run -it --rm --init --entrypoint bash portainer/dev-toolkit:2024.01
# git clone https://github.com/portainer/portainer
# cd portainer
# make build-all
./build/download_binaries.sh: line 10: jq: command not found
make: *** [Makefile:47: server-deps] Error 127

# apt install jq
# make build-all
Downloading binaries for docker v24.0.7, docker-compose v2.24.6, helm v3.13.3, kubectl v1.29.0, and mingit 2.42.0.2
mkdir: created directory '.tmp'
mkdir: created directory '.tmp/download'
(...)
```