### PR TITLE
update alapenna toolkit to use workspace mount

### DIFF
--- a/user-toolkits/alapenna/Dockerfile
+++ b/user-toolkits/alapenna/Dockerfile
@@ -1,9 +1,7 @@
-FROM portainer/dev-toolkit:2024.10
+FROM portainer/dev-toolkit:2024.11
 
-# Create a workspace folder and link it to /root/workspace
-# I also create specific folders for SSH keys and Git configuration
-RUN mkdir -p /workspace /root/.ssh /root/.config/git && \
-    ln -s /workspace /root/workspace
+# Create a specific folder for Git configurations
+RUN mkdir -p /root/.config/git
 
 # Install httpie: http://httpie.io/
 RUN curl -SsL https://packages.httpie.io/deb/KEY.gpg | apt-key add - \

--- a/user-toolkits/alapenna/README.md
+++ b/user-toolkits/alapenna/README.md
@@ -6,11 +6,15 @@ It includes the following tools:
 * httpie for easy HTTP requesting (http://httpie.io/)
 * air for golang app live reload (https://github.com/air-verse/air)
 
-I store my repositories in `/root/workspace` (which is a symlink to `/workspace`).
+This dev container is a bit different from the base dev container. It creates a Docker volume and mounts it at `/workspace`. All the code for my projects are stored in this folder/volume.
+
+This is supposed to provide better performances: https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-a-named-volume-for-your-entire-source-tree
+
+
 It includes a few folders shared with the host:
 * `/root/.ssh`: for SSH keys
 * `/root/.gnupg`: for GPG keys
-* `/workspace`: for all my git repositories that I have on my host
+* `/src`: this contains all the repositories that I have already cloned on my machine - handy if I need to copy across to `/workspace`.
 * `/share-tmp`: for sharing temporary files between the host and the container
 
 For more details, see the `devcontainer.json` and the `Dockerfile` files in this directory.

--- a/user-toolkits/alapenna/devcontainer.json
+++ b/user-toolkits/alapenna/devcontainer.json
@@ -1,7 +1,8 @@
 {
 	"name": "portainer-dev-toolkit",
 	"image": "portainer-dev-toolkit:alapenna",
-	"forwardPorts": [6443, 8000, 8999, 9000, 9443],
+	"forwardPorts": [6443, 8999, 9000],
+	"appPort": [8000, 9443],
 	"mounts": [
 		"source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind",
 		"source=${localEnv:HOME}/.gnupg,target=/root/.gnupg,type=bind",

--- a/user-toolkits/alapenna/devcontainer.json
+++ b/user-toolkits/alapenna/devcontainer.json
@@ -5,10 +5,11 @@
 	"mounts": [
 		"source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind",
 		"source=${localEnv:HOME}/.gnupg,target=/root/.gnupg,type=bind",
-		"source=${localEnv:HOME}/workspaces/toolkit-workspace,target=/workspace,type=bind",
 		"source=${localEnv:HOME}/tmp/dev-toolkit,target=/share-tmp,type=bind",
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
 	],
+	"workspaceMount": "source=portainer-dev-toolkit,target=/workspace,type=volume",
+	"workspaceFolder": "/workspace",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/user-toolkits/alapenna/devcontainer.json
+++ b/user-toolkits/alapenna/devcontainer.json
@@ -1,11 +1,12 @@
 {
 	"name": "portainer-dev-toolkit",
 	"image": "portainer-dev-toolkit:alapenna",
-	"forwardPorts": [8000, 8999, 9000, 9443],
+	"forwardPorts": [6443, 8000, 8999, 9000, 9443],
 	"mounts": [
 		"source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind",
 		"source=${localEnv:HOME}/.gnupg,target=/root/.gnupg,type=bind",
 		"source=${localEnv:HOME}/tmp/dev-toolkit,target=/share-tmp,type=bind",
+		"source=${localEnv:HOME}/workspaces/toolkit-workspace,target=/src,type=bind",
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
 	],
 	"workspaceMount": "source=portainer-dev-toolkit,target=/workspace,type=volume",


### PR DESCRIPTION
I'm still experimenting with this approach - the goal here is to store the code inside a named volume instead of using bind mounts.

For reference: https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-a-named-volume-for-your-entire-source-tree