### PR TITLE
Add Apple Container toolkit for macOS VM-isolated development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,10 @@ GitHub Actions workflow builds multi-arch images (amd64, arm64) on tag push and 
 3. Build: `docker buildx build -t my-devkit -f path/to/Dockerfile .`
 4. Update `devcontainer.json` image field to use your custom image
 
+## Troubleshooting from Inside a Devbox
+
+When the user reports an issue from a running devbox container, check `$DEVBOX_GIT_COMMIT` to see which commit the image was built from. A `-dirty` suffix means the build included uncommitted local changes. If the value disagrees with the user's expectation (e.g. they expected a recent fix to be present), the image likely wasn't actually rebuilt.
+
 ## Version Management
 
 Current version: `VERSION=2026.05` in Makefile. Releasing:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,10 @@ GitHub Actions workflow builds multi-arch images (amd64, arm64) on tag push and 
 
 When the user reports an issue from a running devbox container, check `$DEVBOX_GIT_COMMIT` to see which commit the image was built from. A `-dirty` suffix means the build included uncommitted local changes. If the value disagrees with the user's expectation (e.g. they expected a recent fix to be present), the image likely wasn't actually rebuilt.
 
+## Apple Container Build Failures
+
+If `make alapenna-container` (or any `container build` against `user-toolkits/alapenna-container/`) fails immediately with `Error: unavailable: "Stream unexpectedly closed."` — this is [apple/container#735](https://github.com/apple/container/issues/735), a ~16KB gRPC header cap on the Dockerfile. The CLI dies before buildkit ever sees the build. Comments and blank lines count toward the limit. Fix: shrink the Dockerfile (strip inline comments, move long-form rationale to the toolkit README). Do not bisect the Dockerfile content looking for a "bad" line — the file is structurally fine, it just exceeds the wire-level cap.
+
 ## Version Management
 
 Current version: `VERSION=2026.05` in Makefile. Releasing:

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ alapenna-container:
 	mkdir -p $(HOME)/.local/bin
 	cp user-toolkits/alapenna-container/devbox-apple $(HOME)/.local/bin/devbox-apple
 	chmod +x $(HOME)/.local/bin/devbox-apple
-	$(HOME)/.local/bin/devbox-apple build
+	cd user-toolkits/alapenna-container && $(HOME)/.local/bin/devbox-apple build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Note: these can be overriden on the command line e.g. `make VERSION=2026.05`
 VERSION=2026.05
 
-.PHONY: base-amd64 base-arm64 base alapenna alapenna-ghostty
+.PHONY: base-amd64 base-arm64 base alapenna alapenna-ghostty alapenna-container
 
 base-amd64:
 	docker build --push --platform=linux/amd64 -t portainer/dev-toolkit:$(VERSION)-amd64 -f Dockerfile .
@@ -22,3 +22,11 @@ alapenna:
 
 alapenna-ghostty:
 	docker build --platform=linux/arm64 -t portainer-dev-toolkit:alapenna-ghostty -f user-toolkits/alapenna-ghostty/Dockerfile .
+
+# Install/update the devbox-apple script into ~/.local/bin and rebuild the image.
+# Requires Apple's `container` CLI (macOS 26+ on Apple Silicon).
+alapenna-container:
+	mkdir -p $(HOME)/.local/bin
+	cp user-toolkits/alapenna-container/devbox-apple $(HOME)/.local/bin/devbox-apple
+	chmod +x $(HOME)/.local/bin/devbox-apple
+	$(HOME)/.local/bin/devbox-apple build

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir -p /root/.zsh \
 RUN mkdir -p /root/.config && cat > /root/.config/starship.toml <<'EOF'
 format = """
 $directory\
+$hostname\
 $git_branch\
 $git_status\
 $line_break\
@@ -52,9 +53,14 @@ style = "cyan bold"
 truncation_length = 5
 truncate_to_repo = false
 
+[hostname]
+ssh_only = false
+format = "[ @ $hostname]($style)"
+style = "yellow bold"
+
 [git_branch]
 style = "purple bold"
-format = "[│ $symbol$branch]($style)"
+format = "[ │ $symbol$branch]($style)"
 symbol = ""
 
 [git_status]
@@ -138,8 +144,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 # ============================================
 # glow (markdown reader)
 # ============================================
-RUN go install github.com/charmbracelet/glow@latest \
-    && go clean -cache -modcache
+RUN GLOW_VERSION=$(curl -s "https://api.github.com/repos/charmbracelet/glow/releases/latest" | grep -Po '"tag_name": "v\K[^"]*') \
+    && ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
+    && curl -Lo glow.tar.gz "https://github.com/charmbracelet/glow/releases/download/v${GLOW_VERSION}/glow_${GLOW_VERSION}_Linux_${ARCH}.tar.gz" \
+    && tar xf glow.tar.gz glow \
+    && mv glow /usr/local/bin/ \
+    && rm glow.tar.gz
 
 # ============================================
 # Claude Code + Plannotator CLI
@@ -263,9 +273,9 @@ export PATH="$HOME/.local/bin:$PATH"
 export EDITOR="fresh"
 export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
 
-# Plannotator (devcontainer mode on port 8999)
+# Plannotator (devcontainer mode on port 17777)
 export PLANNOTATOR_REMOTE=1
-export PLANNOTATOR_PORT=8999
+export PLANNOTATOR_PORT=17777
 
 # ----------------------------------------
 # Tool integrations

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -147,9 +147,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 RUN GLOW_VERSION=$(curl -s "https://api.github.com/repos/charmbracelet/glow/releases/latest" | grep -Po '"tag_name": "v\K[^"]*') \
     && ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
     && curl -Lo glow.tar.gz "https://github.com/charmbracelet/glow/releases/download/v${GLOW_VERSION}/glow_${GLOW_VERSION}_Linux_${ARCH}.tar.gz" \
-    && tar xf glow.tar.gz glow \
-    && mv glow /usr/local/bin/ \
-    && rm glow.tar.gz
+    && tar xzf glow.tar.gz \
+    && mv glow_*/glow /usr/local/bin/ \
+    && rm -rf glow.tar.gz glow_*
 
 # ============================================
 # Claude Code + Plannotator CLI

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -208,6 +208,7 @@ RUN cat > $HOME/.claude/settings.json <<'EOF'
     "deny": [
       "Read(**/.env*)",
       "Read(~/.ssh/**)",
+      "Read(~/.gnupg/**)",
       "Read(~/.docker/**)"
     ]
   }

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -158,8 +158,8 @@ RUN claude plugin marketplace add jarrodwatts/claude-hud \
     && claude plugin install gopls-lsp@claude-plugins-official
 
 # Claude Code config files
-RUN mkdir -p /root/.claude/plugins/claude-hud \
-    && cat > /root/.claude/plugins/claude-hud/config.json <<'EOF'
+RUN mkdir -p $HOME/.claude/plugins/claude-hud \
+    && cat > $HOME/.claude/plugins/claude-hud/config.json <<'EOF'
 {
   "layout": "default",
   "display": {
@@ -181,7 +181,7 @@ RUN mkdir -p /root/.claude/plugins/claude-hud \
 }
 EOF
 
-RUN cat > /root/.claude/settings.json <<'EOF'
+RUN cat > $HOME/.claude/settings.json <<'EOF'
 {
   "statusLine": {
     "type": "command",
@@ -195,7 +195,8 @@ RUN cat > /root/.claude/settings.json <<'EOF'
   "permissions": {
     "deny": [
       "Read(**/.env*)",
-      "Read(~/.ssh/**)"
+      "Read(~/.ssh/**)",
+      "Read(~/.docker/**)"
     ]
   }
 }

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -24,7 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf $(which fdfind) /usr/local/bin/fd \
-    && ln -sf $(which batcat) /usr/local/bin/bat
+    && ln -sf $(which batcat) /usr/local/bin/bat \
+    && mkdir -p /usr/share/fzf \
+    && curl -fsSL https://raw.githubusercontent.com/junegunn/fzf/refs/heads/master/shell/key-bindings.zsh -o /usr/share/fzf/key-bindings.zsh
 
 # ============================================
 # zsh plugins (no oh-my-zsh) + starship prompt
@@ -252,7 +254,7 @@ bindkey '^[[A' history-substring-search-up
 bindkey '^[[B' history-substring-search-down
 
 # fzf keybindings (Ctrl+R history, Ctrl+T files, Alt+C cd)
-source /usr/share/doc/fzf/examples/key-bindings.zsh
+source /usr/share/fzf/key-bindings.zsh
 
 # ----------------------------------------
 # Environment

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM portainer/dev-toolkit:2026.05
+FROM portainer/dev-toolkit:2025.12
 
 ENV HOME=/root
 ENV TERM=xterm-256color
@@ -319,8 +319,8 @@ EOF
 # ============================================
 # Custom scripts
 # ============================================
-COPY user-toolkits/alapenna-ghostty/scripts/ccm /usr/local/bin/ccm
-COPY user-toolkits/alapenna-ghostty/scripts/entrypoint.sh /entrypoint.sh
+COPY scripts/ccm /usr/local/bin/ccm
+COPY scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /usr/local/bin/ccm /entrypoint.sh
 
 # ============================================

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM portainer/dev-toolkit:2025.12
+FROM portainer/dev-toolkit:2026.05
 
 ENV HOME=/root
 ENV TERM=xterm-256color

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -2,6 +2,11 @@ FROM portainer/dev-toolkit:2025.12
 
 ENV HOME=/root
 ENV TERM=xterm-256color
+ENV COLORTERM=truecolor
+ENV EDITOR=fresh
+ENV FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
+ENV PLANNOTATOR_REMOTE=1
+ENV PLANNOTATOR_PORT=17777
 
 # Detect architecture for binary downloads
 ARG TARGETARCH
@@ -266,17 +271,6 @@ bindkey '^[[B' history-substring-search-down
 
 # fzf keybindings (Ctrl+R history, Ctrl+T files, Alt+C cd)
 source /usr/share/fzf/key-bindings.zsh
-
-# ----------------------------------------
-# Environment
-# ----------------------------------------
-export PATH="$HOME/.local/bin:$PATH"
-export EDITOR="fresh"
-export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
-
-# Plannotator (devcontainer mode on port 17777)
-export PLANNOTATOR_REMOTE=1
-export PLANNOTATOR_PORT=17777
 
 # ----------------------------------------
 # Tool integrations

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -168,10 +168,12 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/root/.local/bin:${PATH}"
 RUN claude plugin marketplace add jarrodwatts/claude-hud \
     && claude plugin marketplace add anthropics/claude-plugins-official \
+    && claude plugin marketplace add deviantony/claude-plugins \
     && claude plugin install claude-hud \
     && claude plugin install typescript-lsp@claude-plugins-official \
     && claude plugin install gopls-lsp@claude-plugins-official \
-    && claude plugin install skill-creator@claude-plugins-official
+    && claude plugin install skill-creator@claude-plugins-official \
+    && claude plugin install cdx@deviantony-plugins
 
 # Claude Code config files
 RUN mkdir -p $HOME/.claude/plugins/claude-hud \

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -170,7 +170,8 @@ RUN claude plugin marketplace add jarrodwatts/claude-hud \
     && claude plugin marketplace add anthropics/claude-plugins-official \
     && claude plugin install claude-hud \
     && claude plugin install typescript-lsp@claude-plugins-official \
-    && claude plugin install gopls-lsp@claude-plugins-official
+    && claude plugin install gopls-lsp@claude-plugins-official \
+    && claude plugin install skill-creator@claude-plugins-official
 
 # Claude Code config files
 RUN mkdir -p $HOME/.claude/plugins/claude-hud \

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -206,7 +206,11 @@ RUN cat > $HOME/.claude/settings.json <<'EOF'
     "command": "node \"$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)dist/index.js\""
   },
   "enabledPlugins": {
-    "claude-hud@claude-hud": true
+    "claude-hud@claude-hud": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "cdx@deviantony-plugins": true
   },
   "permissions": {
     "deny": [
@@ -336,6 +340,14 @@ RUN chmod +x /usr/local/bin/ccm /entrypoint.sh
 # Set zsh as default shell
 # ============================================
 RUN chsh -s $(which zsh)
+
+# ============================================
+# Build provenance
+# Placed last so changing the commit doesn't bust earlier layer cache.
+# Inspect inside the container with: echo $DEVBOX_GIT_COMMIT
+# ============================================
+ARG GIT_COMMIT=unknown
+ENV DEVBOX_GIT_COMMIT=${GIT_COMMIT}
 
 WORKDIR /workspace
 SHELL ["/bin/zsh", "-c"]

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -285,6 +285,7 @@ alias cat="bat --paging=never"
 alias l="eza -la --icons"
 alias br='fzf --preview "bat --color=always {}"'
 alias gp="git push"
+alias cl="claude --dangerously-skip-permissions"
 
 dir() { eza --tree --level="${1:-1}" --icons; }
 
@@ -314,6 +315,7 @@ ha() {
 
   Productivity
     ccm         Claude commit message
+    cl          Claude (skip permissions)
 "
 }
 

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -13,6 +13,15 @@ ARG TARGETARCH
 
 # ============================================
 # System packages (combined, with cleanup)
+#
+# Grouped by purpose:
+#   - Shell/CLI ergonomics: zsh, fzf, ripgrep, fd-find, bat, jq, lsof, file
+#   - Networking + archive: wget, curl, unzip
+#   - Git signing: gnupg
+#   - Swift toolchain runtime/build deps (per swift.org Ubuntu 24.04 list)
+#     installed alongside swiftly further down. libcurl/libxml2/libz3/libedit
+#     are linked by the toolchain; libgcc-13/libstdc++-13/libc6 supply the
+#     C++ runtime; libpython3 is needed for lldb's Python bindings.
 # ============================================
 RUN apt-get update && apt-get install -y --no-install-recommends \
     zsh \
@@ -28,6 +37,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lsof \
     unzip \
     gnupg \
+    binutils \
+    libc6-dev \
+    libcurl4-openssl-dev \
+    libedit2 \
+    libgcc-13-dev \
+    libncurses-dev \
+    libpython3-dev \
+    libsqlite3-0 \
+    libstdc++-13-dev \
+    libxml2-dev \
+    libz3-dev \
+    pkg-config \
+    tzdata \
+    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf $(which fdfind) /usr/local/bin/fd \
     && ln -sf $(which batcat) /usr/local/bin/bat \
@@ -158,6 +181,26 @@ RUN GLOW_VERSION=$(curl -s "https://api.github.com/repos/charmbracelet/glow/rele
     && rm -rf glow.tar.gz glow_*
 
 # ============================================
+# Swift toolchain (via swiftly)
+# Latest stable toolchain. System deps are in the apt block at the top.
+# --no-modify-profile: we manage .zshrc ourselves; the SWIFTLY_* ENV vars
+# below replace the env.sh that swiftly would otherwise source from a
+# profile file. Toolchain binaries (swift, swiftc, lldb…) are symlinked
+# into SWIFTLY_BIN_DIR (/root/.local/bin), which we put on PATH.
+# ============================================
+ENV SWIFTLY_HOME_DIR=/root/.local/share/swiftly
+ENV SWIFTLY_BIN_DIR=/root/.local/bin
+ENV SWIFTLY_TOOLCHAINS_DIR=/root/.local/share/swiftly/toolchains
+ENV PATH="${SWIFTLY_BIN_DIR}:${PATH}"
+
+RUN ARCH=$(uname -m) \
+    && cd /tmp \
+    && curl -fsSLO "https://download.swift.org/swiftly/linux/swiftly-${ARCH}.tar.gz" \
+    && tar -xzf "swiftly-${ARCH}.tar.gz" \
+    && ./swiftly init --assume-yes --quiet-shell-followup --no-modify-profile \
+    && rm -rf "swiftly-${ARCH}.tar.gz" swiftly LICENSE.txt
+
+# ============================================
 # Claude Code
 # ============================================
 RUN curl -fsSL https://claude.ai/install.sh | bash
@@ -165,7 +208,6 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # ============================================
 # Claude Code plugins (via CLI)
 # ============================================
-ENV PATH="/root/.local/bin:${PATH}"
 RUN claude plugin marketplace add jarrodwatts/claude-hud \
     && claude plugin marketplace add anthropics/claude-plugins-official \
     && claude plugin marketplace add deviantony/claude-plugins \

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     file \
-    fzf \
     ripgrep \
     fd-find \
     bat \
@@ -45,9 +44,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf $(which fdfind) /usr/local/bin/fd \
-    && ln -sf $(which batcat) /usr/local/bin/bat \
+    && ln -sf $(which batcat) /usr/local/bin/bat
+
+# fzf: install latest upstream release. Debian's package (0.44.1) is too old
+# for the master shell/key-bindings.zsh, which uses flags like --wrap-sign
+# added in 0.49.0 — version skew makes Ctrl+R silently bail.
+RUN FZF_VERSION=$(curl -s "https://api.github.com/repos/junegunn/fzf/releases/latest" | grep -Po '"tag_name": "v\K[^"]*') \
+    && ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
+    && curl -Lo fzf.tar.gz "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_${ARCH}.tar.gz" \
+    && tar xf fzf.tar.gz -C /usr/local/bin/ fzf \
+    && rm fzf.tar.gz \
     && mkdir -p /usr/share/fzf \
-    && curl -fsSL https://raw.githubusercontent.com/junegunn/fzf/refs/heads/master/shell/key-bindings.zsh -o /usr/share/fzf/key-bindings.zsh
+    && curl -fsSL "https://raw.githubusercontent.com/junegunn/fzf/v${FZF_VERSION}/shell/key-bindings.zsh" -o /usr/share/fzf/key-bindings.zsh
 
 # ============================================
 # zsh plugins (no oh-my-zsh) + starship prompt
@@ -305,9 +313,14 @@ setopt CORRECT               # Spelling correction for commands
 # ----------------------------------------
 # Key bindings
 # ----------------------------------------
-# Up/down arrow searches history with current prefix
+# Substring history search on Up/Down. Bind both the normal (`^[[A`) and
+# application-cursor (`^[OA`) escape sequences — apple/container's TTY
+# exec delivers `^[OA`, so binding only `^[[A` silently falls through to
+# the default `up-line-or-history` (plain chronological walk).
 bindkey '^[[A' history-substring-search-up
+bindkey '^[OA' history-substring-search-up
 bindkey '^[[B' history-substring-search-down
+bindkey '^[OB' history-substring-search-down
 
 # fzf keybindings (Ctrl+R history, Ctrl+T files, Alt+C cd)
 source /usr/share/fzf/key-bindings.zsh

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -5,6 +5,8 @@ ENV TERM=xterm-256color
 ENV COLORTERM=truecolor
 ENV EDITOR=fresh
 ENV FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
+# Allows `claude --dangerously-skip-permissions` when running as root inside the container
+ENV IS_SANDBOX=1
 
 # Detect architecture for binary downloads
 ARG TARGETARCH

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -58,7 +58,7 @@ truncate_to_repo = false
 
 [hostname]
 ssh_only = false
-format = "[ @ $hostname]($style)"
+format = "[@ $hostname]($style)"
 style = "yellow bold"
 
 [git_branch]

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -13,15 +13,6 @@ ARG TARGETARCH
 
 # ============================================
 # System packages (combined, with cleanup)
-#
-# Grouped by purpose:
-#   - Shell/CLI ergonomics: zsh, fzf, ripgrep, fd-find, bat, jq, lsof, file
-#   - Networking + archive: wget, curl, unzip
-#   - Git signing: gnupg
-#   - Swift toolchain runtime/build deps (per swift.org Ubuntu 24.04 list)
-#     installed alongside swiftly further down. libcurl/libxml2/libz3/libedit
-#     are linked by the toolchain; libgcc-13/libstdc++-13/libc6 supply the
-#     C++ runtime; libpython3 is needed for lldb's Python bindings.
 # ============================================
 RUN apt-get update && apt-get install -y --no-install-recommends \
     zsh \
@@ -37,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lsof \
     unzip \
     gnupg \
+    socat \
     binutils \
     libc6-dev \
     libcurl4-openssl-dev \
@@ -182,11 +174,6 @@ RUN GLOW_VERSION=$(curl -s "https://api.github.com/repos/charmbracelet/glow/rele
 
 # ============================================
 # Swift toolchain (via swiftly)
-# Latest stable toolchain. System deps are in the apt block at the top.
-# --no-modify-profile: we manage .zshrc ourselves; the SWIFTLY_* ENV vars
-# below replace the env.sh that swiftly would otherwise source from a
-# profile file. Toolchain binaries (swift, swiftc, lldb…) are symlinked
-# into SWIFTLY_BIN_DIR (/root/.local/bin), which we put on PATH.
 # ============================================
 ENV SWIFTLY_HOME_DIR=/root/.local/share/swiftly
 ENV SWIFTLY_BIN_DIR=/root/.local/bin
@@ -206,6 +193,12 @@ RUN ARCH=$(uname -m) \
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # ============================================
+# Xcode MCP server registration
+# ============================================
+RUN claude mcp add --scope user --transport stdio xcode -- \
+    socat - UNIX-CONNECT:/var/run/xcode-mcp.sock
+
+# ============================================
 # Claude Code plugins (via CLI)
 # ============================================
 RUN claude plugin marketplace add jarrodwatts/claude-hud \
@@ -214,6 +207,7 @@ RUN claude plugin marketplace add jarrodwatts/claude-hud \
     && claude plugin install claude-hud \
     && claude plugin install typescript-lsp@claude-plugins-official \
     && claude plugin install gopls-lsp@claude-plugins-official \
+    && claude plugin install swift-lsp@claude-plugins-official \
     && claude plugin install skill-creator@claude-plugins-official \
     && claude plugin install cdx@deviantony-plugins
 
@@ -251,6 +245,7 @@ RUN cat > $HOME/.claude/settings.json <<'EOF'
     "claude-hud@claude-hud": true,
     "typescript-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
+    "swift-lsp@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "cdx@deviantony-plugins": true
   },

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     lsof \
     unzip \
+    gnupg \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf $(which fdfind) /usr/local/bin/fd \
     && ln -sf $(which batcat) /usr/local/bin/bat \

--- a/user-toolkits/alapenna-container/Dockerfile
+++ b/user-toolkits/alapenna-container/Dockerfile
@@ -5,8 +5,6 @@ ENV TERM=xterm-256color
 ENV COLORTERM=truecolor
 ENV EDITOR=fresh
 ENV FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
-ENV PLANNOTATOR_REMOTE=1
-ENV PLANNOTATOR_PORT=17777
 
 # Detect architecture for binary downloads
 ARG TARGETARCH
@@ -157,20 +155,17 @@ RUN GLOW_VERSION=$(curl -s "https://api.github.com/repos/charmbracelet/glow/rele
     && rm -rf glow.tar.gz glow_*
 
 # ============================================
-# Claude Code + Plannotator CLI
+# Claude Code
 # ============================================
-RUN curl -fsSL https://claude.ai/install.sh | bash \
-    && curl -fsSL https://plannotator.ai/install.sh | bash
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # ============================================
 # Claude Code plugins (via CLI)
 # ============================================
 ENV PATH="/root/.local/bin:${PATH}"
 RUN claude plugin marketplace add jarrodwatts/claude-hud \
-    && claude plugin marketplace add backnotprop/plannotator \
     && claude plugin marketplace add anthropics/claude-plugins-official \
     && claude plugin install claude-hud \
-    && claude plugin install plannotator@plannotator \
     && claude plugin install typescript-lsp@claude-plugins-official \
     && claude plugin install gopls-lsp@claude-plugins-official
 
@@ -205,10 +200,8 @@ RUN cat > $HOME/.claude/settings.json <<'EOF'
     "command": "node \"$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)dist/index.js\""
   },
   "enabledPlugins": {
-    "claude-hud@claude-hud": true,
-    "plannotator@plannotator": true
+    "claude-hud@claude-hud": true
   },
-  "alwaysThinkingEnabled": true,
   "permissions": {
     "deny": [
       "Read(**/.env*)",

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -59,7 +59,10 @@ devbox-apple
 | `devbox-apple destroy` | Remove the container |
 | `devbox-apple status` | Show container/image status |
 | `devbox-apple build` | Build the image from Dockerfile |
+| `devbox-apple build --keep-builder` | Build and keep builder running (faster rebuilds) |
 | `devbox-apple rebuild` | Destroy container and rebuild image |
+| `devbox-apple rebuild --keep-builder` | Rebuild and keep builder running |
+| `devbox-apple builder-configure [cpus] [memory]` | Configure builder resources (e.g., `8 8g`) |
 | `devbox-apple logs` | Show container logs |
 
 ## Directory Mounts
@@ -82,26 +85,43 @@ Edit `devbox-apple` script to customize mount paths.
 - **Terminal**: zsh, starship, fzf, ripgrep, fd, bat, eza
 - **Files**: yazi, zoxide, glow
 - **Editor**: fresh
-- **AI**: Claude Code with plugins (claude-hud, plannotator)
+- **AI**: Claude Code with plugins (claude-hud, plannotator on port 17777)
 - **Scripts**: ccm (Claude commit message generator)
 
-## Port Forwarding
+## Builder Configuration
 
-The container exposes ports **10000-19999** to avoid conflicts with host services.
+The build process uses a separate builder VM (managed by Apple container). By default, it's configured for **8 CPUs / 8GB RAM** for fast builds.
 
-Suggested port assignments for common services:
+**After each build, the builder is automatically removed** to free resources back to your Mac. This means:
+- ✓ Build completes → 8 CPUs / 8GB freed immediately
+- ✓ Your devbox container has full resources available
+- ⚠ Next build will recreate builder (~10-30 seconds overhead)
+
+**For active Dockerfile development** (frequent rebuilds), keep the builder running:
+
+```bash
+devbox-apple rebuild --keep-builder  # Faster subsequent builds
+```
+
+**To change builder resources:**
+
+```bash
+# Use 4 CPUs / 4GB for builds (if RAM-limited)
+devbox-apple builder-configure 4 4g
+
+# Or edit script permanently
+# Set: BUILDER_CPUS=4 and BUILDER_MEMORY="4g"
+```
+
+## Port Configuration
+
+The container exposes ports **10000-19999** (mapped 1:1 to host) to avoid conflicts with system services.
+
+### Pre-configured Services
 
 | Port | Service |
 |------|---------|
-| 19000 | Portainer HTTP |
-| 19443 | Portainer HTTPS |
-| 18999 | Plannotator |
-| 16443 | Kubernetes API |
-| 13000-13999 | Frontend dev servers |
-| 14000-14999 | Backend APIs |
-| 15000-15999 | Databases/services |
-
-Configure your applications to bind to these high ports to avoid conflicts.
+| 17777 | Plannotator |
 
 ## Isolation Benefits
 

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -1,0 +1,145 @@
+# alapenna-container toolkit
+
+A development environment using Apple's native container CLI on macOS 26+.
+
+## Why Apple Container?
+
+| Feature | Docker/OrbStack | Apple Container |
+|---------|-----------------|-----------------|
+| Architecture | Shared Linux VM | VM-per-container |
+| Isolation | Shared kernel | Full VM isolation |
+| Host mounts | OrbStack auto-mounts /Users | Explicit only |
+| Startup | ~2 sec | ~0.7 sec |
+| Maintained by | Docker Inc / OrbStack | Apple |
+
+Each container runs in its own lightweight VM, providing true isolation without shared attack surfaces.
+
+## Prerequisites
+
+- macOS 26 (Tahoe) or later
+- Apple Silicon Mac
+
+## Installing Apple Container CLI
+
+Follow the official installation guide: [apple/container - Install or Upgrade](https://github.com/apple/container?tab=readme-ov-file#install-or-upgrade)
+
+Verify installation:
+
+```bash
+container --version
+container system status
+```
+
+## Quick Start
+
+```bash
+# 1. Build the image
+cd user-toolkits/alapenna-container
+devbox-apple build
+
+# 2. Start and enter the container
+devbox-apple
+
+# 3. You're in! Multiple terminals can connect
+```
+
+## Install devbox-apple script
+
+```bash
+cp devbox-apple ~/.local/bin/
+chmod +x ~/.local/bin/devbox-apple
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `devbox-apple` | Enter container (creates if needed) |
+| `devbox-apple stop` | Stop the container |
+| `devbox-apple destroy` | Remove the container |
+| `devbox-apple status` | Show container/image status |
+| `devbox-apple build` | Build the image from Dockerfile |
+| `devbox-apple logs` | Show container logs |
+
+## Directory Mounts
+
+| Host | Container | Mode |
+|------|-----------|------|
+| `~/workspaces/toolkit-workspace` | `/workspace` | read-write |
+| `~/.ssh` | `/root/.ssh` | read-only |
+| `~/.gnupg` | `/root/.gnupg` | read-only |
+| `~/tmp/dev-toolkit` | `/share-tmp` | read-write |
+
+Edit `devbox` script to customize mount paths.
+
+## Included Tools
+
+- **Languages**: Go, Node.js, Yarn (from base image)
+- **Git**: lazygit, delta, gh
+- **Terminal**: zsh, starship, fzf, ripgrep, fd, bat, eza
+- **Files**: yazi, zoxide, glow
+- **Editor**: fresh
+- **AI**: Claude Code with plugins (claude-hud, plannotator)
+- **Scripts**: ccm (Claude commit message generator)
+
+## Port Forwarding
+
+| Port | Service |
+|------|---------|
+| 6443 | Kubernetes API |
+| 8999 | Plannotator |
+| 9000 | Portainer HTTP |
+| 9443 | Portainer HTTPS |
+
+## Isolation Benefits
+
+Unlike OrbStack which [auto-mounts /Users and /Volumes](https://github.com/orbstack/orbstack/issues/169), Apple container only mounts what you explicitly configure. This makes it suitable for running untrusted code (like AI agents) in a sandboxed environment.
+
+## Known Limitations
+
+- **No snapshots yet**: The `container` CLI doesn't expose VM snapshot/restore (though Virtualization.framework supports it)
+- **Pre-1.0**: API may change between versions
+- **Image unpacking**: Can be slow for large images
+
+## Future Enhancements
+
+Potential wrapper features to build:
+- Snapshot/restore via Swift (using Virtualization.framework APIs)
+- Multiple named containers
+- Container profiles (different resource allocations)
+
+## Troubleshooting
+
+### Container won't start
+
+```bash
+# Check system status
+container system status
+
+# View logs
+container system logs
+```
+
+### Image not found
+
+```bash
+# Build locally
+devbox build
+
+# Or pull from registry (if published)
+container image pull your-registry/devbox:latest
+```
+
+### Permission errors on mounts
+
+Ensure the mount source directories exist and are readable:
+
+```bash
+mkdir -p ~/workspaces/toolkit-workspace ~/tmp/dev-toolkit
+```
+
+## References
+
+- [apple/container](https://github.com/apple/container) - CLI tool
+- [apple/containerization](https://github.com/apple/containerization) - Swift framework
+- [Virtualization.framework](https://developer.apple.com/documentation/virtualization) - Apple docs

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -18,6 +18,7 @@ Each container runs in its own lightweight VM, providing true isolation without 
 
 - macOS 26 (Tahoe) or later
 - Apple Silicon Mac
+- zsh shell (default on macOS)
 
 ## Installing Apple Container CLI
 
@@ -31,6 +32,8 @@ container system status
 ```
 
 ## Install devbox-apple script
+
+**Note:** The `devbox-apple` script requires `zsh` (default shell on macOS).
 
 ```bash
 cd user-toolkits/alapenna-container

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -118,8 +118,9 @@ git config --global user.signingkey <GPG_KEY_ID>
 ### 2. GitHub CLI Authentication (Browser-Based)
 
 After copying credentials, GitHub CLI authentication starts automatically:
-- Browser opens with a one-time code
-- Authorize the device in your browser
+- Browser opens on your Mac to https://github.com/login/device
+- A one-time code is displayed in the terminal
+- Enter the code in your browser to authorize
 - Authentication persists across container restarts
 
 Settings applied automatically:

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -59,6 +59,7 @@ devbox-apple
 | `devbox-apple destroy` | Remove the container |
 | `devbox-apple status` | Show container/image status |
 | `devbox-apple build` | Build the image from Dockerfile |
+| `devbox-apple rebuild` | Destroy container and rebuild image |
 | `devbox-apple logs` | Show container logs |
 
 ## Directory Mounts

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -66,11 +66,13 @@ chmod +x ~/.local/bin/devbox-apple
 | Host | Container | Mode |
 |------|-----------|------|
 | `~/workspaces/toolkit-workspace` | `/workspace` | read-write |
-| `~/.ssh` | `/root/.ssh` | read-only |
-| `~/.gnupg` | `/root/.gnupg` | read-only |
+| `~/.ssh` | `/root/.ssh` | copied |
+| `~/.gnupg` | `/root/.gnupg` | copied |
 | `~/tmp/dev-toolkit` | `/share-tmp` | read-write |
 
-Edit `devbox` script to customize mount paths.
+Note: SSH and GPG directories are copied into the container on first creation, not live-mounted from the host.
+
+Edit `devbox-apple` script to customize mount paths.
 
 ## Included Tools
 
@@ -124,7 +126,7 @@ container system logs
 
 ```bash
 # Build locally
-devbox build
+devbox-apple build
 
 # Or pull from registry (if published)
 container image pull your-registry/devbox:latest

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -82,6 +82,61 @@ SSH and GPG credentials are copied into the container once during initial setup.
 
 **Note:** Edit the `devbox-apple` script to customize paths.
 
+## First Time Setup
+
+On first container creation, setup runs automatically in this order:
+
+### 1. Automatic Configuration (No Interaction)
+
+**Git Identity & Signing:**
+- `user.email` - copied from host
+- `user.name` - copied from host
+- `user.signingkey` - copied from host (if configured)
+- `commit.gpgsign` - enabled if signing key exists
+- `push.autoSetupRemote` - enabled automatically
+
+**Credentials:**
+- SSH keys from `~/.ssh` - copied to container
+- GPG keys from `~/.gnupg` - copied to container
+
+**Requirements on Host Mac:**
+
+Ensure your host Mac has git configured before creating the container:
+
+```bash
+# Verify your host git config
+git config --global user.email
+git config --global user.name
+git config --global user.signingkey
+
+# If missing, configure on your Mac:
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
+git config --global user.signingkey <GPG_KEY_ID>
+```
+
+### 2. GitHub CLI Authentication (Browser-Based)
+
+After copying credentials, GitHub CLI authentication starts automatically:
+- Browser opens with a one-time code
+- Authorize the device in your browser
+- Authentication persists across container restarts
+
+Settings applied automatically:
+- Git protocol: SSH
+- SSH key upload: Skipped (keys already copied from host)
+
+### 3. Claude Code Authentication (First Use)
+
+Authenticate Claude Code the first time you run it:
+
+```bash
+claude
+# Follow the authentication prompts
+```
+
+Authentication persists across container restarts.
+
 ## Included Tools
 
 - **Languages**: Go, Node.js, Yarn (from base image)

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -102,8 +102,12 @@ Unlike OrbStack which [auto-mounts /Users and /Volumes](https://github.com/orbst
 - **No snapshots yet**: The `container` CLI doesn't expose VM snapshot/restore (though Virtualization.framework supports it)
 - **Pre-1.0**: API may change between versions
 - **Image unpacking**: Can be slow for large images
+- **No Docker socket mounting (yet)**: Single file/socket mounting [was merged](https://github.com/apple/containerization/pull/487) on 2026-01-23 but not yet released (current: 0.8.0). Expected in a future release. Until then, use Docker CLI from your host Mac instead of inside the container
 
 ## Future Enhancements
+
+Coming in next container CLI release:
+- Docker socket mounting (merged, awaiting release - see Known Limitations)
 
 Potential wrapper features to build:
 - Snapshot/restore via Swift (using Virtualization.framework APIs)

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -86,12 +86,21 @@ Edit `devbox-apple` script to customize mount paths.
 
 ## Port Forwarding
 
+The container exposes ports **10000-19999** to avoid conflicts with host services.
+
+Suggested port assignments for common services:
+
 | Port | Service |
 |------|---------|
-| 6443 | Kubernetes API |
-| 8999 | Plannotator |
-| 9000 | Portainer HTTP |
-| 9443 | Portainer HTTPS |
+| 19000 | Portainer HTTP |
+| 19443 | Portainer HTTPS |
+| 18999 | Plannotator |
+| 16443 | Kubernetes API |
+| 13000-13999 | Frontend dev servers |
+| 14000-14999 | Backend APIs |
+| 15000-15999 | Databases/services |
+
+Configure your applications to bind to these high ports to avoid conflicts.
 
 ## Isolation Benefits
 

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -30,24 +30,24 @@ container --version
 container system status
 ```
 
+## Install devbox-apple script
+
+```bash
+cd user-toolkits/alapenna-container
+cp devbox-apple ~/.local/bin/
+chmod +x ~/.local/bin/devbox-apple
+```
+
 ## Quick Start
 
 ```bash
 # 1. Build the image
-cd user-toolkits/alapenna-container
 devbox-apple build
 
 # 2. Start and enter the container
 devbox-apple
 
 # 3. You're in! Multiple terminals can connect
-```
-
-## Install devbox-apple script
-
-```bash
-cp devbox-apple ~/.local/bin/
-chmod +x ~/.local/bin/devbox-apple
 ```
 
 ## Commands

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -66,7 +66,7 @@ devbox-apple
 
 | Host | Container | Access |
 |------|-----------|--------|
-| `~/workspaces/toolkit-workspace` | `/workspace` | read-write |
+| `~/workspaces/applecntr-workspace` | `/workspace` | read-write |
 | `~/tmp/dev-toolkit` | `/share-tmp` | read-write |
 | `/var/run/docker.sock` | `/var/run/docker.sock` | read-write (auto-detected) |
 

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -197,6 +197,7 @@ The container exposes ports **10000-19999** (mapped 1:1 to host) to avoid confli
 - **Pre-1.0**: API may change between versions
 - **Image unpacking**: Can be slow for large images
 - **Docker socket cross-volume caveat**: Docker socket mounting works via [single file mount support](https://github.com/apple/containerization/pull/487). Since sockets use kernel IPC (not file I/O), the cross-volume write limitation does not apply
+- **IPv4-only network workaround**: `devbox-apple` creates and uses a dedicated IPv4-only network (`devbox-apple-net`, `192.168.100.0/24`) instead of the default network. Apple's `container` runtime assigns IPv6 ULAs via SLAAC but doesn't install an IPv6 default route — NAT66 is not yet implemented (see [apple/container#1034](https://github.com/apple/container/issues/1034)). Without this workaround, tools with weak Happy Eyeballs fallback (notably Node's `fetch`/`undici`, used by corepack/npm/pnpm) hang to timeout on IPv6 instead of retrying over IPv4. Remove the workaround once apple/container ships working IPv6 egress.
 
 ## Future Enhancements
 

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -196,7 +196,6 @@ The container exposes ports **10000-19999** (mapped 1:1 to host) to avoid confli
 - **No snapshots yet**: The `container` CLI doesn't expose VM snapshot/restore (though Virtualization.framework supports it)
 - **Pre-1.0**: API may change between versions
 - **Image unpacking**: Can be slow for large images
-- **Docker socket cross-volume caveat**: Docker socket mounting works via [single file mount support](https://github.com/apple/containerization/pull/487). Since sockets use kernel IPC (not file I/O), the cross-volume write limitation does not apply
 - **IPv4-only network workaround**: `devbox-apple` creates and uses a dedicated IPv4-only network (`devbox-apple-net`, `192.168.100.0/24`) instead of the default network. Apple's `container` runtime assigns IPv6 ULAs via SLAAC but doesn't install an IPv6 default route — NAT66 is not yet implemented (see [apple/container#1034](https://github.com/apple/container/issues/1034)). Without this workaround, tools with weak Happy Eyeballs fallback (notably Node's `fetch`/`undici`, used by corepack/npm/pnpm) hang to timeout on IPv6 instead of retrying over IPv4. Remove the workaround once apple/container ships working IPv6 egress.
 
 ## Future Enhancements

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -146,7 +146,7 @@ Authentication persists across container restarts.
 - **Terminal**: zsh, starship, fzf, ripgrep, fd, bat, eza
 - **Files**: yazi, zoxide, glow
 - **Editor**: fresh
-- **AI**: Claude Code with plugins (claude-hud, plannotator)
+- **AI**: Claude Code with plugins (claude-hud)
 - **Scripts**: ccm (Claude commit message generator)
 
 ## Builder Configuration
@@ -190,12 +190,6 @@ devbox-apple rebuild                 # Final build removes builder
 ## Port Configuration
 
 The container exposes ports **10000-19999** (mapped 1:1 to host) to avoid conflicts with system services.
-
-### Pre-configured Services
-
-| Port | Service |
-|------|---------|
-| 17777 | Plannotator |
 
 ## Known Limitations
 

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -68,8 +68,9 @@ devbox-apple
 |------|-----------|--------|
 | `~/workspaces/toolkit-workspace` | `/workspace` | read-write |
 | `~/tmp/dev-toolkit` | `/share-tmp` | read-write |
+| `/var/run/docker.sock` | `/var/run/docker.sock` | read-write (auto-detected) |
 
-These directories are mounted and changes sync immediately between host and container.
+These directories are mounted and changes sync immediately between host and container. The Docker socket is mounted automatically when detected on the host.
 
 ### Copied Directories (One-Time)
 
@@ -201,12 +202,9 @@ The container exposes ports **10000-19999** (mapped 1:1 to host) to avoid confli
 - **No snapshots yet**: The `container` CLI doesn't expose VM snapshot/restore (though Virtualization.framework supports it)
 - **Pre-1.0**: API may change between versions
 - **Image unpacking**: Can be slow for large images
-- **No Docker socket mounting (yet)**: Single file/socket mounting [was merged](https://github.com/apple/containerization/pull/487) on 2026-01-23 but not yet released (current: 0.8.0). Expected in a future release. Until then, use Docker CLI from your host Mac instead of inside the container
+- **Docker socket cross-volume caveat**: Docker socket mounting works via [single file mount support](https://github.com/apple/containerization/pull/487). Since sockets use kernel IPC (not file I/O), the cross-volume write limitation does not apply
 
 ## Future Enhancements
-
-Coming in next container CLI release:
-- Docker socket mounting (merged, awaiting release - see Known Limitations)
 
 Potential wrapper features to build:
 - Snapshot/restore via Swift (using Virtualization.framework APIs)

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -24,10 +24,6 @@ container --version
 container system status
 ```
 
-## Isolation Benefits
-
-Unlike OrbStack which [auto-mounts /Users and /Volumes](https://github.com/orbstack/orbstack/issues/169), Apple container only mounts what you explicitly configure. Each container runs in its own lightweight VM, providing true isolation without shared attack surfaces. This makes it suitable for running untrusted code (like AI agents) in a sandboxed environment.
-
 ## Install devbox-apple script
 
 **Note:** The `devbox-apple` script requires `zsh` (default shell on macOS).

--- a/user-toolkits/alapenna-container/README.md
+++ b/user-toolkits/alapenna-container/README.md
@@ -7,6 +7,11 @@ A development environment using Apple's native container CLI on macOS 26+.
 - macOS 26 (Tahoe) or later
 - Apple Silicon Mac
 - zsh shell (default on macOS)
+- Xcode 16 or later with command-line tools
+- [`xcodebuildmcp`](https://www.xcodebuildmcp.com/) on the host (`brew install getsentry/xcodebuildmcp/xcodebuildmcp`) — the MCP server that backs the in-container Xcode integration
+- `socat` on the host (`brew install socat`) — used to expose `xcodebuildmcp` over a Unix socket the container can reach
+
+`devbox-apple` will refuse to start the container if `socat` or `xcodebuildmcp` is missing. If you don't want the Xcode integration, edit `devbox-apple` and remove the `start_xcode_bridge` calls in `cmd_enter`.
 
 ## Installing Apple Container CLI
 
@@ -69,8 +74,9 @@ devbox-apple
 | `~/workspaces/applecntr-workspace` | `/workspace` | read-write |
 | `~/tmp/dev-toolkit` | `/share-tmp` | read-write |
 | `/var/run/docker.sock` | `/var/run/docker.sock` | read-write (auto-detected) |
+| `~/tmp/dev-toolkit/xcode-mcp.sock` | `/var/run/xcode-mcp.sock` | Xcode MCP bridge socket (managed by `devbox-apple`) |
 
-These directories are mounted and changes sync immediately between host and container. The Docker socket is mounted automatically when detected on the host.
+These directories are mounted and changes sync immediately between host and container. The Docker socket is mounted automatically when detected on the host. The Xcode MCP socket is created by `devbox-apple` on container start and torn down on stop — see [Xcode MCP integration](#xcode-mcp-integration) below.
 
 ### Copied Directories (One-Time)
 
@@ -146,8 +152,74 @@ Authentication persists across container restarts.
 - **Terminal**: zsh, starship, fzf, ripgrep, fd, bat, eza
 - **Files**: yazi, zoxide, glow
 - **Editor**: fresh
-- **AI**: Claude Code with plugins (claude-hud)
+- **AI**: Claude Code with plugins (claude-hud) and pre-registered Xcode MCP server
 - **Scripts**: ccm (Claude commit message generator)
+
+## Xcode MCP integration
+
+Claude Code inside the container can drive Xcode tooling on the host via [xcodebuildmcp](https://www.xcodebuildmcp.com/) — an MCP server that exposes ~79 tools across iOS, macOS, watchOS, tvOS, and visionOS workflows.
+
+### How it works
+
+`xcodebuildmcp` is a macOS-only stdio binary that shells out to `xcodebuild`, `xcrun`, `simctl`, and `devicectl` — it can't run inside the Linux container directly, and it doesn't expose a TCP port. Instead, `devbox-apple` runs a `socat` listener on the Mac that wraps `xcodebuildmcp mcp` behind a Unix socket, then mounts that socket into the container the same way `/var/run/docker.sock` is mounted. An MCP server entry pre-registered in the image (`claude mcp list` → `xcode`) relays Claude's stdio to the mounted socket via in-container `socat`.
+
+### Workflow scoping
+
+The bridge is scoped to iOS+macOS-relevant workflows by default via `XCODEBUILDMCP_ENABLED_WORKFLOWS`. To adjust, edit `XCODEBUILDMCP_WORKFLOWS` near the top of `devbox-apple` — see the [workflows reference](https://www.xcodebuildmcp.com/docs/workflows) for the full list. To enable Xcode IDE-only features (preview rendering, Issue Navigator, doc search), add `xcode-ide` to the list — that workflow proxies `xcrun mcpbridge` under the hood and requires Xcode 26.3+ with the **Xcode Tools** toggle in *Xcode → Settings → Intelligence*.
+
+### Lifecycle
+
+The bridge is tied to the container — there is no always-on listener on the Mac.
+
+| `devbox-apple` action | Bridge effect |
+|-----------------------|---------------|
+| Create container (first run) | Spawns `socat` listener, bakes the socket mount into the container |
+| Resume stopped container | Re-spawns `socat` listener (mount was baked in at create time) |
+| `devbox-apple stop` | Kills the listener, removes socket and PID files |
+| `devbox-apple destroy` | Same teardown as `stop` |
+| External `container stop devbox-apple` | Listener orphans; reaped on next `devbox-apple` start or stop |
+
+### Verifying the connection
+
+Inside the container:
+
+```bash
+ls -la /var/run/xcode-mcp.sock   # leading 's' = Unix socket, mount worked
+claude mcp list                  # 'xcode' should be listed
+```
+
+Then start `claude` and run `/mcp` — `xcode` should be `connected`.
+
+### Troubleshooting
+
+Bridge log on the Mac (most useful first stop for any "xcode failed to reconnect" / unhealthy MCP issue):
+
+```bash
+tail -f ~/tmp/dev-toolkit/.xcode-mcp.log
+```
+
+What it shows: `xcodebuildmcp` startup banner and registered workflows, per-call traces, errors from the host-side server. If the log is empty, the listener didn't start — check `socat` and `xcodebuildmcp` are on `$PATH` on the Mac.
+
+Other quick checks:
+
+```bash
+# Mac: is the listener running?
+cat ~/tmp/dev-toolkit/.xcode-mcp.pid && ps -p "$(cat ~/tmp/dev-toolkit/.xcode-mcp.pid)"
+
+# Mac: connect manually to confirm the socket end-to-end
+socat - UNIX-CONNECT:$HOME/tmp/dev-toolkit/xcode-mcp.sock
+
+# Container: socket present and is a socket (leading 's')?
+ls -la /var/run/xcode-mcp.sock
+```
+
+If the bridge is wedged, `devbox-apple stop && devbox-apple` re-spawns the listener cleanly.
+
+### Security properties
+
+- Socket lives at mode `600` in `~/tmp/dev-toolkit/` — only your user can connect.
+- No network port, no remote login enabled on the host.
+- `xcodebuildmcp` is spawned per-connection with the same blast radius as you running it manually.
 
 ## Builder Configuration
 
@@ -187,16 +259,38 @@ devbox-apple rebuild --keep-builder  # Reuses existing builder (fast!)
 devbox-apple rebuild                 # Final build removes builder
 ```
 
-## Port Configuration
+## Networking
 
-The container exposes ports **10000-19999** (mapped 1:1 to host) to avoid conflicts with system services.
+The container runs on apple/container's default network — no port range is published. Services bound to `0.0.0.0` inside the container are reachable from the Mac directly at the container's IP:
+
+```bash
+devbox-apple status              # prints the container's IP
+# Container: running
+# IP:        192.168.64.2
+#            (services bound to 0.0.0.0 in-container reachable at http://192.168.64.2:<port>)
+```
+
+Then from your Mac browser/CLI:
+
+```
+http://192.168.64.2:5173/        # Vite, etc.
+```
+
+Practical notes:
+- Services that bind only to `127.0.0.1` (Vite's default, for instance) are *not* reachable from the Mac. Use `--host` / `host: true` / equivalent to bind to all interfaces.
+- This trades a little discoverability (you need the IP) for honesty (no aliasing through localhost). And no port collisions with whatever else is running on your Mac.
+- **macOS Local Network permission is per-app.** If `curl` from the Mac reaches the container fine but a browser shows `ERR_ADDRESS_UNREACHABLE`, the browser hasn't been granted Local Network access. Open *System Settings → Privacy & Security → Local Network* and enable the browser (Arc, Chrome, etc.). Safari is implicitly trusted; `curl` inherits Terminal's grant.
+
+### Why not use `--publish`?
+
+Direct IP access on the default network is cleaner: no port-collision juggling with whatever else is running on your Mac, and `http://<container-ip>:<port>` is honest about where the service actually lives.
 
 ## Known Limitations
 
 - **No snapshots yet**: The `container` CLI doesn't expose VM snapshot/restore (though Virtualization.framework supports it)
 - **Pre-1.0**: API may change between versions
 - **Image unpacking**: Can be slow for large images
-- **IPv4-only network workaround**: `devbox-apple` creates and uses a dedicated IPv4-only network (`devbox-apple-net`, `192.168.100.0/24`) instead of the default network. Apple's `container` runtime assigns IPv6 ULAs via SLAAC but doesn't install an IPv6 default route — NAT66 is not yet implemented (see [apple/container#1034](https://github.com/apple/container/issues/1034)). Without this workaround, tools with weak Happy Eyeballs fallback (notably Node's `fetch`/`undici`, used by corepack/npm/pnpm) hang to timeout on IPv6 instead of retrying over IPv4. Remove the workaround once apple/container ships working IPv6 egress.
+- **Dockerfile size cap (~16KB)**: `container build` sends the Dockerfile in a gRPC header, which is bound by gRPC's 16KB default. Hitting the cap fails immediately with `Error: unavailable: "Stream unexpectedly closed."` (or `Transport became inactive` on older CLI versions) — see [apple/container#735](https://github.com/apple/container/issues/735). Workaround: keep the Dockerfile lean. Inline comments and blank lines count toward the limit, so when adding heavy explanatory prose, put it in a sibling notes file rather than inside the Dockerfile.
 
 ## Future Enhancements
 
@@ -216,6 +310,12 @@ container system status
 # View logs
 container system logs
 ```
+
+### `container build` fails with "Stream unexpectedly closed"
+
+Almost always means you've crossed the ~16KB Dockerfile size cap (gRPC header limit, [apple/container#735](https://github.com/apple/container/issues/735)). The build dies in milliseconds, before reaching buildkit — `container logs buildkit` will show no session for the failed attempt.
+
+Confirm by stripping inline comments / blank lines from the Dockerfile until the build succeeds. Long-form rationale belongs in this README or a notes file, not in the Dockerfile.
 
 ## References
 

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -78,11 +78,18 @@ copy_credential_dir() {
   local files=("$src"/*)
   if [[ -d "$src" ]] && [[ -e "${files[1]}" ]]; then
     echo "Copying $name..."
+
     for f in "${files[@]}"; do
-      [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "$dst/$(basename "$f")" > /dev/null
+      if [[ -f "$f" ]]; then
+        cat "$f" | container exec -i "$NAME" tee "$dst/$(basename "$f")" > /dev/null
+      elif [[ -d "$f" ]]; then
+        local dirname="$(basename "$f")"
+        container exec "$NAME" mkdir -p "$dst/$dirname"
+        tar -C "$src/$dirname" -cf - . 2>/dev/null | container exec -i "$NAME" tar -C "$dst/$dirname" -xf - 2>/dev/null || true
+      fi
     done
-    container exec "$NAME" chmod 700 "$dst"
-    container exec "$NAME" chmod 600 "$dst"/* 2>/dev/null || true
+
+    container exec "$NAME" sh -c "chmod 700 '$dst' && find '$dst' -type f -exec chmod 600 {} +"
   else
     echo "  (no $name found, skipping)"
   fi

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -32,7 +32,7 @@ GNUPG_DIR="$HOME/.gnupg"
 CONTAINER_CPUS=4
 CONTAINER_MEMORY="8g"
 
-# Builder configuration
+# Builder configuration (default: performance profile)
 BUILDER_CPUS=8
 BUILDER_MEMORY="8g"
 
@@ -215,17 +215,17 @@ cmd_build() {
     local current_mem_gb="${resources[2]}"
     echo "Using existing builder: ${current_cpus} CPUs / ${current_mem_gb}g"
 
-    # Check for mismatch with script defaults
-    local target_mem_mb=$((${BUILDER_MEMORY%g} * 1024))
-    local current_mem_mb=$(echo "$current_builder" | awk '{print $6}')
-    if [[ "$current_cpus" != "$BUILDER_CPUS" ]] || [[ "$current_mem_mb" != "$target_mem_mb" ]]; then
+    # Check for mismatch with recommended performance profile (8 CPUs / 8g)
+    local recommended_cpus=8
+    local recommended_mem_gb=8
+    if [[ "$current_cpus" != "$recommended_cpus" ]] || [[ "$current_mem_gb" != "$recommended_mem_gb" ]]; then
       echo ""
-      echo "⚠️  WARNING: Builder config doesn't match script defaults"
-      echo "   Current:  ${current_cpus} CPUs / ${current_mem_gb}g"
-      echo "   Default:  ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY}"
+      echo "⚠️  WARNING: Builder doesn't match recommended performance profile"
+      echo "   Current:      ${current_cpus} CPUs / ${current_mem_gb}g"
+      echo "   Recommended:  ${recommended_cpus} CPUs / ${recommended_mem_gb}g (performance profile)"
       echo ""
-      echo "Build may be slower/faster than expected."
-      echo "To use defaults, run: devbox-apple builder-configure"
+      echo "Build may be slower than expected."
+      echo "To use recommended config, run: devbox-apple builder-configure performance"
       echo ""
       read "reply?Continue with current builder? [y/N] "
       echo ""
@@ -296,10 +296,43 @@ cmd_logs() {
 cmd_builder_configure() {
   check_container_cli
 
-  local cpus="${1:-$BUILDER_CPUS}"
-  local memory="${2:-$BUILDER_MEMORY}"
+  local profile="${1:-performance}"
+  local cpus memory
 
-  echo "Configuring builder: ${cpus} CPUs / ${memory}"
+  # Map profile to resources
+  case "$profile" in
+    light)
+      cpus=2
+      memory="2g"
+      ;;
+    balanced)
+      cpus=4
+      memory="4g"
+      ;;
+    performance)
+      cpus=8
+      memory="8g"
+      ;;
+    max)
+      cpus=12
+      memory="16g"
+      ;;
+    *)
+      echo "Error: Unknown profile '$profile'"
+      echo ""
+      echo "Available profiles:"
+      echo "  light        2 CPUs / 2g   - Minimal resource use"
+      echo "  balanced     4 CPUs / 4g   - Good for most builds"
+      echo "  performance  8 CPUs / 8g   - Fast builds (recommended)"
+      echo "  max          12 CPUs / 16g - Maximum performance"
+      echo ""
+      echo "Usage: devbox-apple builder-configure [profile]"
+      echo "Example: devbox-apple builder-configure performance"
+      exit 1
+      ;;
+  esac
+
+  echo "Configuring builder: ${profile} profile (${cpus} CPUs / ${memory})"
   echo ""
 
   # Stop and remove existing builder
@@ -334,17 +367,26 @@ cmd_help() {
   echo "  build               Build the container image"
   echo "  rebuild             Destroy container and rebuild image"
   echo "  logs                Show container logs"
-  echo "  builder-configure   Configure builder resources (cpus memory)"
+  echo "  builder-configure   Configure builder resources with preset profiles"
   echo "  help                Show this help"
   echo ""
   echo "Build Options:"
   echo "  --keep-builder      Don't remove builder after build (faster rebuilds)"
   echo ""
+  echo "Builder Profiles:"
+  echo "  performance  8 CPUs / 8g   - Fast builds (recommended, default)"
+  echo "  light        2 CPUs / 2g   - Minimal resource use"
+  echo "  balanced     4 CPUs / 4g   - Good for most builds"
+  echo "  max          12 CPUs / 16g - Maximum performance"
+  echo ""
+  echo "  Usage: devbox-apple builder-configure [profile]"
+  echo "  Default: devbox-apple builder-configure  (uses performance)"
+  echo ""
   echo "Container Resources:"
   echo "  CPUs:    $CONTAINER_CPUS"
   echo "  Memory:  $CONTAINER_MEMORY"
   echo ""
-  echo "Builder Resources:"
+  echo "Builder Resources (current script default):"
   echo "  CPUs:    $BUILDER_CPUS"
   echo "  Memory:  $BUILDER_MEMORY"
   echo "  Auto-remove after build: yes (use --keep-builder to prevent)"

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -207,9 +207,9 @@ cmd_build() {
       echo "Build may be slower/faster than expected."
       echo "To use defaults, run: devbox-apple builder-configure"
       echo ""
-      read -p "Continue with current builder? [y/N] " -n 1 -r
+      read "reply?Continue with current builder? [y/N] "
       echo ""
-      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      if [[ ! $reply =~ ^[Yy]$ ]]; then
         echo "Build cancelled."
         exit 0
       fi

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -1,19 +1,23 @@
 #!/usr/bin/env zsh
 # devbox-apple - Container lifecycle manager using Apple container CLI
 #
-# Requires: macOS 26+ with Apple container CLI
+# Requires: macOS 26+ with Apple container CLI, zsh shell
 #
 # Install:
 #   cp devbox-apple ~/.local/bin/
 #   chmod +x ~/.local/bin/devbox-apple
 #
 # Usage:
-#   devbox-apple          # Enter the container (creates/starts if needed)
-#   devbox-apple stop     # Stop the container
-#   devbox-apple destroy  # Remove container
-#   devbox-apple status   # Show container status
-#   devbox-apple build    # Build the image
-#   devbox-apple logs     # Show container logs
+#   devbox-apple                      # Enter the container (creates/starts if needed)
+#   devbox-apple stop                 # Stop the container
+#   devbox-apple destroy              # Remove container
+#   devbox-apple status               # Show container status
+#   devbox-apple build                # Build the image
+#   devbox-apple build --keep-builder # Build and keep builder for faster rebuilds
+#   devbox-apple rebuild              # Destroy container and rebuild image
+#   devbox-apple builder-configure    # Configure builder resources (performance/balanced/light/max)
+#   devbox-apple logs                 # Show container logs
+#   devbox-apple help                 # Show detailed help
 
 set -e
 

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -284,7 +284,7 @@ cmd_builder_configure() {
   # Stop and remove existing builder
   if container builder status 2>/dev/null | grep -q "^buildkit"; then
     echo "Removing existing builder..."
-    container builder delete buildkit
+    container builder delete
     echo ""
   fi
 

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -28,6 +28,10 @@ SHARE_TMP="$HOME/tmp/dev-toolkit"
 SSH_DIR="$HOME/.ssh"
 GNUPG_DIR="$HOME/.gnupg"
 
+# Builder configuration
+BUILDER_CPUS=8
+BUILDER_MEMORY="8g"
+
 check_container_cli() {
   if ! command -v container &>/dev/null; then
     echo "Apple container CLI not found."
@@ -175,7 +179,35 @@ cmd_status() {
 cmd_build() {
   check_container_cli
 
+  # Parse flags
+  local keep_builder=false
+  if [[ "$1" == "--keep-builder" ]]; then
+    keep_builder=true
+  fi
+
   echo "Building image..."
+
+  # Ensure builder has correct resources
+  local current_builder=$(container builder status 2>/dev/null | grep -E "^buildkit" || echo "")
+  if [[ -n "$current_builder" ]]; then
+    # Check if resources match config
+    local current_cpus=$(echo "$current_builder" | awk '{print $6}')
+    local current_mem=$(echo "$current_builder" | awk '{print $7}')
+    local target_mem_mb=$((${BUILDER_MEMORY%g} * 1024))
+
+    if [[ "$current_cpus" != "$BUILDER_CPUS" ]] || [[ "$current_mem" != "$target_mem_mb" ]]; then
+      echo "Reconfiguring builder to ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY}..."
+      container builder delete buildkit 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+
+  # Start builder with configured resources if not running
+  if ! container builder status 2>/dev/null | grep -q "^buildkit.*running"; then
+    echo "Starting builder (${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY})..."
+    container builder start --cpus "$BUILDER_CPUS" --memory "$BUILDER_MEMORY"
+    sleep 2
+  fi
 
   # Find the Dockerfile location
   SCRIPT_DIR="$(dirname "$0")"
@@ -188,9 +220,18 @@ cmd_build() {
     exit 1
   fi
 
+  # Build the image
   container build --tag "$IMAGE" "$BUILD_DIR"
   echo ""
   echo "Image built: $IMAGE"
+
+  # Auto-remove builder unless --keep-builder flag
+  if [[ "$keep_builder" == false ]]; then
+    echo ""
+    echo "Removing builder to free resources (${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY})..."
+    echo "(Use --keep-builder flag to keep builder for faster subsequent builds)"
+    container builder delete buildkit 2>/dev/null || true
+  fi
 }
 
 cmd_rebuild() {
@@ -203,8 +244,8 @@ cmd_rebuild() {
   cmd_destroy
   echo ""
 
-  # Build new image
-  cmd_build
+  # Build new image (pass through any flags like --keep-builder)
+  cmd_build "$@"
 }
 
 cmd_logs() {
@@ -217,20 +258,57 @@ cmd_logs() {
   fi
 }
 
+cmd_builder_configure() {
+  check_container_cli
+
+  local cpus="${1:-$BUILDER_CPUS}"
+  local memory="${2:-$BUILDER_MEMORY}"
+
+  echo "Configuring builder: ${cpus} CPUs / ${memory}"
+  echo ""
+
+  # Stop and remove existing builder
+  if container builder status 2>/dev/null | grep -q "^buildkit"; then
+    echo "Removing existing builder..."
+    container builder delete buildkit
+    echo ""
+  fi
+
+  # Start with new configuration
+  echo "Starting builder with ${cpus} CPUs / ${memory}..."
+  container builder start --cpus "$cpus" --memory "$memory"
+
+  echo ""
+  echo "Builder configured successfully."
+  echo ""
+  echo "To make this permanent, edit the script and set:"
+  echo "  BUILDER_CPUS=${cpus}"
+  echo "  BUILDER_MEMORY=\"${memory}\""
+}
+
 cmd_help() {
   echo "devbox-apple - Container lifecycle manager (Apple container)"
   echo ""
-  echo "Usage: devbox-apple [command]"
+  echo "Usage: devbox-apple [command] [options]"
   echo ""
   echo "Commands:"
-  echo "  (none)    Enter the container (creates if needed)"
-  echo "  stop      Stop the container"
-  echo "  destroy   Remove the container"
-  echo "  status    Show container and image status"
-  echo "  build     Build the container image"
-  echo "  rebuild   Destroy container and rebuild image"
-  echo "  logs      Show container logs"
-  echo "  help      Show this help"
+  echo "  (none)              Enter the container (creates if needed)"
+  echo "  stop                Stop the container"
+  echo "  destroy             Remove the container"
+  echo "  status              Show container and image status"
+  echo "  build               Build the container image"
+  echo "  rebuild             Destroy container and rebuild image"
+  echo "  logs                Show container logs"
+  echo "  builder-configure   Configure builder resources (cpus memory)"
+  echo "  help                Show this help"
+  echo ""
+  echo "Build Options:"
+  echo "  --keep-builder      Don't remove builder after build (faster rebuilds)"
+  echo ""
+  echo "Builder Config (current):"
+  echo "  CPUs:    $BUILDER_CPUS"
+  echo "  Memory:  $BUILDER_MEMORY"
+  echo "  Auto-remove after build: yes (use --keep-builder to prevent)"
   echo ""
   echo "Mounted:"
   echo "  $WORKSPACE_DIR -> /workspace"
@@ -258,13 +336,19 @@ case "${1:-}" in
     cmd_status
     ;;
   build)
-    cmd_build
+    shift
+    cmd_build "$@"
     ;;
   rebuild)
-    cmd_rebuild
+    shift
+    cmd_rebuild "$@"
     ;;
   logs)
     cmd_logs
+    ;;
+  builder-configure)
+    shift
+    cmd_builder_configure "$@"
     ;;
   help|--help|-h)
     cmd_help

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -187,27 +187,29 @@ cmd_build() {
 
   echo "Building image..."
 
-  # Ensure builder has correct resources
+  # Check current builder status
   local current_builder=$(container builder status 2>/dev/null | grep -E "^buildkit" || echo "")
   if [[ -n "$current_builder" ]]; then
-    # Check if resources match config
+    # Builder exists, show actual config
     local current_cpus=$(echo "$current_builder" | awk '{print $6}')
-    local current_mem=$(echo "$current_builder" | awk '{print $7}')
+    local current_mem_mb=$(echo "$current_builder" | awk '{print $7}')
+    local current_mem_gb=$((current_mem_mb / 1024))
+    echo "Using existing builder: ${current_cpus} CPUs / ${current_mem_gb}g"
+
+    # Check if it matches script defaults
     local target_mem_mb=$((${BUILDER_MEMORY%g} * 1024))
-
-    if [[ "$current_cpus" != "$BUILDER_CPUS" ]] || [[ "$current_mem" != "$target_mem_mb" ]]; then
-      echo "Reconfiguring builder to ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY}..."
-      container builder delete buildkit 2>/dev/null || true
-      sleep 1
+    if [[ "$current_cpus" != "$BUILDER_CPUS" ]] || [[ "$current_mem_mb" != "$target_mem_mb" ]]; then
+      echo "(Script default: ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY} - use 'devbox-apple builder-configure' to reconfigure)"
     fi
-  fi
-
-  # Start builder with configured resources if not running
-  if ! container builder status 2>/dev/null | grep -q "^buildkit.*running"; then
-    echo "Starting builder (${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY})..."
+  else
+    # No builder, will create with script defaults
+    echo "Builder configuration: ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY}"
+    echo "Starting builder..."
     container builder start --cpus "$BUILDER_CPUS" --memory "$BUILDER_MEMORY"
     sleep 2
   fi
+
+  echo ""
 
   # Find the Dockerfile location
   SCRIPT_DIR="$(dirname "$0")"

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -28,6 +28,10 @@ SHARE_TMP="$HOME/tmp/dev-toolkit"
 SSH_DIR="$HOME/.ssh"
 GNUPG_DIR="$HOME/.gnupg"
 
+# Container configuration
+CONTAINER_CPUS=4
+CONTAINER_MEMORY="8g"
+
 # Builder configuration
 BUILDER_CPUS=8
 BUILDER_MEMORY="8g"
@@ -41,36 +45,57 @@ check_container_cli() {
   fi
 }
 
+# Helper: Check if container is running
+container_is_running() {
+  container list 2>/dev/null | grep -q "^$NAME"
+}
+
+# Helper: Check if container exists (running or stopped)
+container_exists() {
+  container list --all 2>/dev/null | grep -q "^$NAME"
+}
+
+# Helper: Check if builder exists
+builder_exists() {
+  container builder status 2>/dev/null | grep -q "^buildkit"
+}
+
+# Helper: Get builder resources (cpus mem_gb)
+get_builder_resources() {
+  local builder="$1"
+  local cpus=$(echo "$builder" | awk '{print $5}')
+  local mem_mb=$(echo "$builder" | awk '{print $6}')
+  local mem_gb=$((mem_mb / 1024))
+  echo "$cpus $mem_gb"
+}
+
+# Helper: Copy credential directory into container
+copy_credential_dir() {
+  local src="$1"
+  local dst="$2"
+  local name="$3"
+
+  local files=("$src"/*)
+  if [[ -d "$src" ]] && [[ -e "${files[0]}" ]]; then
+    echo "Copying $name..."
+    for f in "${files[@]}"; do
+      [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "$dst/$(basename "$f")" > /dev/null
+    done
+    container exec "$NAME" chmod 700 "$dst"
+    container exec "$NAME" chmod 600 "$dst"/* 2>/dev/null || true
+  else
+    echo "  (no $name found, skipping)"
+  fi
+}
+
 # Copy SSH and GPG keys into container (one-time setup)
 setup_credentials() {
-  echo "Copying SSH keys..."
   # Create directories
   container exec "$NAME" mkdir -p /root/.ssh /root/.gnupg
 
-  # Copy SSH files (if they exist)
-  local ssh_files=("$SSH_DIR"/*)
-  if [[ -d "$SSH_DIR" ]] && [[ -e "${ssh_files[0]}" ]]; then
-    for f in "${ssh_files[@]}"; do
-      [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "/root/.ssh/$(basename "$f")" > /dev/null
-    done
-    container exec "$NAME" chmod 700 /root/.ssh
-    container exec "$NAME" chmod 600 /root/.ssh/* 2>/dev/null || true
-  else
-    echo "  (no SSH keys found, skipping)"
-  fi
-
-  # Copy GPG files (if they exist)
-  local gpg_files=("$GNUPG_DIR"/*)
-  if [[ -d "$GNUPG_DIR" ]] && [[ -e "${gpg_files[0]}" ]]; then
-    echo "Copying GPG keys..."
-    for f in "${gpg_files[@]}"; do
-      [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "/root/.gnupg/$(basename "$f")" > /dev/null
-    done
-    container exec "$NAME" chmod 700 /root/.gnupg
-    container exec "$NAME" chmod 600 /root/.gnupg/* 2>/dev/null || true
-  else
-    echo "  (no GPG keys found, skipping)"
-  fi
+  # Copy credentials
+  copy_credential_dir "$SSH_DIR" "/root/.ssh" "SSH keys"
+  copy_credential_dir "$GNUPG_DIR" "/root/.gnupg" "GPG keys"
 
   echo "Credentials setup complete."
 }
@@ -79,7 +104,7 @@ cmd_enter() {
   check_container_cli
 
   # Check if container exists and is running
-  if container list 2>/dev/null | grep -q "^$NAME"; then
+  if container_is_running; then
     # Container exists, exec into it
     exec container exec -ti "$NAME" /bin/zsh -l
   fi
@@ -98,7 +123,7 @@ cmd_enter() {
   #   echo "✓ Docker socket detected - mounting for Docker CLI access"
   #   VOLUME_ARGS+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
   # fi
-  VOLUME_ARGS=(
+  local volume_args=(
     --volume "$WORKSPACE_DIR:/workspace"
     --volume "$SHARE_TMP:/share-tmp"
   )
@@ -109,10 +134,10 @@ cmd_enter() {
   container run \
     --name "$NAME" \
     --detach \
-    --memory 8g \
-    --cpus 4 \
+    --memory "$CONTAINER_MEMORY" \
+    --cpus "$CONTAINER_CPUS" \
     --publish 10000-19999:10000-19999 \
-    "${VOLUME_ARGS[@]}" \
+    "${volume_args[@]}" \
     --ssh \
     "$IMAGE"
 
@@ -129,7 +154,7 @@ cmd_enter() {
 cmd_stop() {
   check_container_cli
 
-  if container list 2>/dev/null | grep -q "^$NAME"; then
+  if container_is_running; then
     echo "Stopping container..."
     container stop "$NAME"
     echo "Container stopped."
@@ -141,15 +166,9 @@ cmd_stop() {
 cmd_destroy() {
   check_container_cli
 
-  if container list --all 2>/dev/null | grep -q "^$NAME"; then
-    # Stop first if running (silently)
-    if container list 2>/dev/null | grep -q "^$NAME"; then
-      echo "Stopping container..."
-      container stop "$NAME"
-    fi
-
+  if container_exists; then
     echo "Removing container..."
-    container delete "$NAME"
+    container delete --force "$NAME"
     echo "Container removed."
   else
     echo "Container does not exist."
@@ -162,10 +181,10 @@ cmd_status() {
   echo "Container CLI: installed"
   echo ""
 
-  if container list 2>/dev/null | grep -q "^$NAME"; then
+  if container_is_running; then
     echo "Container: running"
     container inspect "$NAME" 2>/dev/null | head -20
-  elif container list --all 2>/dev/null | grep -q "^$NAME"; then
+  elif container_exists; then
     echo "Container: stopped"
   else
     echo "Container: not created"
@@ -188,16 +207,17 @@ cmd_build() {
   echo "Building image..."
 
   # Check current builder status
-  local current_builder=$(container builder status 2>/dev/null | grep -E "^buildkit" || echo "")
-  if [[ -n "$current_builder" ]]; then
+  if builder_exists; then
     # Builder exists - use it (respect manual configuration)
-    local current_cpus=$(echo "$current_builder" | awk '{print $5}')
-    local current_mem_mb=$(echo "$current_builder" | awk '{print $6}')
-    local current_mem_gb=$((current_mem_mb / 1024))
+    local current_builder=$(container builder status 2>/dev/null | grep -E "^buildkit")
+    local resources=($(get_builder_resources "$current_builder"))
+    local current_cpus="${resources[1]}"
+    local current_mem_gb="${resources[2]}"
     echo "Using existing builder: ${current_cpus} CPUs / ${current_mem_gb}g"
 
     # Check for mismatch with script defaults
     local target_mem_mb=$((${BUILDER_MEMORY%g} * 1024))
+    local current_mem_mb=$(echo "$current_builder" | awk '{print $6}')
     if [[ "$current_cpus" != "$BUILDER_CPUS" ]] || [[ "$current_mem_mb" != "$target_mem_mb" ]]; then
       echo ""
       echo "⚠️  WARNING: Builder config doesn't match script defaults"
@@ -224,27 +244,28 @@ cmd_build() {
   echo ""
 
   # Find the Dockerfile location
-  SCRIPT_DIR="$(dirname "$0")"
-  if [[ -f "$SCRIPT_DIR/Dockerfile" ]]; then
-    BUILD_DIR="$SCRIPT_DIR"
+  local script_dir="$(dirname "$0")"
+  local build_dir
+  if [[ -f "$script_dir/Dockerfile" ]]; then
+    build_dir="$script_dir"
   elif [[ -f "./Dockerfile" ]]; then
-    BUILD_DIR="."
+    build_dir="."
   else
     echo "Dockerfile not found. Run from the toolkit directory."
     exit 1
   fi
 
   # Build the image
-  container build --tag "$IMAGE" "$BUILD_DIR"
+  container build --tag "$IMAGE" "$build_dir"
   echo ""
   echo "Image built: $IMAGE"
 
   # Auto-remove builder unless --keep-builder flag
   if [[ "$keep_builder" == false ]]; then
     echo ""
-    echo "Removing builder to free resources (${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY})..."
+    echo "Removing builder to free resources..."
     echo "(Use --keep-builder flag to keep builder for faster subsequent builds)"
-    container builder delete buildkit 2>/dev/null || true
+    container builder delete --force 2>/dev/null || true
   fi
 }
 
@@ -265,7 +286,7 @@ cmd_rebuild() {
 cmd_logs() {
   check_container_cli
 
-  if container list --all 2>/dev/null | grep -q "^$NAME"; then
+  if container_exists; then
     container logs "$NAME"
   else
     echo "Container does not exist."
@@ -282,9 +303,9 @@ cmd_builder_configure() {
   echo ""
 
   # Stop and remove existing builder
-  if container builder status 2>/dev/null | grep -q "^buildkit"; then
+  if builder_exists; then
     echo "Removing existing builder..."
-    container builder delete
+    container builder delete --force
     echo ""
   fi
 
@@ -319,7 +340,11 @@ cmd_help() {
   echo "Build Options:"
   echo "  --keep-builder      Don't remove builder after build (faster rebuilds)"
   echo ""
-  echo "Builder Config (current):"
+  echo "Container Resources:"
+  echo "  CPUs:    $CONTAINER_CPUS"
+  echo "  Memory:  $CONTAINER_MEMORY"
+  echo ""
+  echo "Builder Resources:"
   echo "  CPUs:    $BUILDER_CPUS"
   echo "  Memory:  $BUILDER_MEMORY"
   echo "  Auto-remove after build: yes (use --keep-builder to prevent)"
@@ -328,7 +353,7 @@ cmd_help() {
   echo "  $WORKSPACE_DIR -> /workspace"
   echo "  $SHARE_TMP -> /share-tmp"
   echo ""
-  echo "Note: Docker socket mounting not supported (use host Docker CLI)"
+  echo "Note: Docker socket mounting not supported yet (coming soon)"
   echo ""
   echo "Ports:"
   echo "  10000-19999 (mapped 1:1)"

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -138,8 +138,11 @@ cmd_destroy() {
   check_container_cli
 
   if container list --all 2>/dev/null | grep -q "^$NAME"; then
-    # Stop first if running
-    cmd_stop
+    # Stop first if running (silently)
+    if container list 2>/dev/null | grep -q "^$NAME"; then
+      echo "Stopping container..."
+      container stop "$NAME"
+    fi
 
     echo "Removing container..."
     container delete "$NAME"

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -44,25 +44,31 @@ setup_credentials() {
   container exec "$NAME" mkdir -p /root/.ssh /root/.gnupg
 
   # Copy SSH files (if they exist)
-  if [[ -d "$SSH_DIR" ]]; then
-    for f in "$SSH_DIR"/*; do
+  local ssh_files=("$SSH_DIR"/*)
+  if [[ -d "$SSH_DIR" ]] && [[ -e "${ssh_files[0]}" ]]; then
+    for f in "${ssh_files[@]}"; do
       [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "/root/.ssh/$(basename "$f")" > /dev/null
     done
     container exec "$NAME" chmod 700 /root/.ssh
     container exec "$NAME" chmod 600 /root/.ssh/* 2>/dev/null || true
+  else
+    echo "  (no SSH keys found, skipping)"
   fi
 
   # Copy GPG files (if they exist)
-  if [[ -d "$GNUPG_DIR" ]]; then
+  local gpg_files=("$GNUPG_DIR"/*)
+  if [[ -d "$GNUPG_DIR" ]] && [[ -e "${gpg_files[0]}" ]]; then
     echo "Copying GPG keys..."
-    for f in "$GNUPG_DIR"/*; do
+    for f in "${gpg_files[@]}"; do
       [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "/root/.gnupg/$(basename "$f")" > /dev/null
     done
     container exec "$NAME" chmod 700 /root/.gnupg
     container exec "$NAME" chmod 600 /root/.gnupg/* 2>/dev/null || true
+  else
+    echo "  (no GPG keys found, skipping)"
   fi
 
-  echo "Credentials copied."
+  echo "Credentials setup complete."
 }
 
 cmd_enter() {
@@ -181,6 +187,23 @@ cmd_build() {
   echo "Image built: $IMAGE"
 }
 
+cmd_rebuild() {
+  check_container_cli
+
+  echo "Rebuilding container (destroy + build)..."
+  echo ""
+
+  # Destroy if exists
+  if container list --all 2>/dev/null | grep -q "^$NAME"; then
+    echo "Removing existing container..."
+    container delete "$NAME"
+    echo ""
+  fi
+
+  # Build
+  cmd_build
+}
+
 cmd_logs() {
   check_container_cli
 
@@ -202,6 +225,7 @@ cmd_help() {
   echo "  destroy   Remove the container"
   echo "  status    Show container and image status"
   echo "  build     Build the container image"
+  echo "  rebuild   Destroy container and rebuild image"
   echo "  logs      Show container logs"
   echo "  help      Show this help"
   echo ""
@@ -232,6 +256,9 @@ case "${1:-}" in
     ;;
   build)
     cmd_build
+    ;;
+  rebuild)
+    cmd_rebuild
     ;;
   logs)
     cmd_logs

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -1,0 +1,235 @@
+#!/usr/bin/env zsh
+# devbox-apple - Container lifecycle manager using Apple container CLI
+#
+# Requires: macOS 26+ with Apple container CLI
+#
+# Install:
+#   cp devbox-apple ~/.local/bin/
+#   chmod +x ~/.local/bin/devbox-apple
+#
+# Usage:
+#   devbox-apple          # Enter the container (creates/starts if needed)
+#   devbox-apple stop     # Stop the container
+#   devbox-apple destroy  # Remove container
+#   devbox-apple status   # Show container status
+#   devbox-apple build    # Build the image
+#   devbox-apple logs     # Show container logs
+
+set -e
+
+NAME="devbox-apple"
+IMAGE="devbox-apple:latest"
+
+# Paths (adjust to your setup)
+WORKSPACE_DIR="$HOME/workspaces/toolkit-workspace"
+SHARE_TMP="$HOME/tmp/dev-toolkit"
+
+# Source directories for initial copy (not mounted)
+SSH_DIR="$HOME/.ssh"
+GNUPG_DIR="$HOME/.gnupg"
+
+check_container_cli() {
+  if ! command -v container &>/dev/null; then
+    echo "Apple container CLI not found."
+    echo "Requires macOS 26+ with container CLI installed."
+    echo "See: https://github.com/apple/container"
+    exit 1
+  fi
+}
+
+# Copy SSH and GPG keys into container (one-time setup)
+setup_credentials() {
+  echo "Copying SSH keys..."
+  # Create directories
+  container exec "$NAME" mkdir -p /root/.ssh /root/.gnupg
+
+  # Copy SSH files (if they exist)
+  if [[ -d "$SSH_DIR" ]]; then
+    for f in "$SSH_DIR"/*; do
+      [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "/root/.ssh/$(basename "$f")" > /dev/null
+    done
+    container exec "$NAME" chmod 700 /root/.ssh
+    container exec "$NAME" chmod 600 /root/.ssh/* 2>/dev/null || true
+  fi
+
+  # Copy GPG files (if they exist)
+  if [[ -d "$GNUPG_DIR" ]]; then
+    echo "Copying GPG keys..."
+    for f in "$GNUPG_DIR"/*; do
+      [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "/root/.gnupg/$(basename "$f")" > /dev/null
+    done
+    container exec "$NAME" chmod 700 /root/.gnupg
+    container exec "$NAME" chmod 600 /root/.gnupg/* 2>/dev/null || true
+  fi
+
+  echo "Credentials copied."
+}
+
+cmd_enter() {
+  check_container_cli
+
+  # Check if container exists and is running
+  if container list 2>/dev/null | grep -q "^$NAME"; then
+    # Container exists, exec into it
+    exec container exec -ti "$NAME" /bin/zsh -l
+  fi
+
+  # Container doesn't exist, create and start it
+  echo "Creating container..."
+
+  # Ensure directories exist
+  mkdir -p "$WORKSPACE_DIR" "$SHARE_TMP"
+
+  # Start container in detached mode
+  # Note: Apple container uses FIXED allocation per VM (not shared like OrbStack)
+  # Default is 1GB RAM / 4 CPUs - too low for dev work, so we override.
+  container run \
+    --name "$NAME" \
+    --detach \
+    --memory 8g \
+    --cpus 4 \
+    --publish 6443-9999:6443-9999 \
+    --volume "$WORKSPACE_DIR:/workspace" \
+    --volume "$SHARE_TMP:/share-tmp" \
+    --volume "/var/run/docker.sock:/var/run/docker.sock" \
+    --ssh \
+    "$IMAGE"
+
+  # Wait for container to be ready
+  sleep 2
+
+  # Copy credentials on first creation
+  setup_credentials
+
+  # Enter the container
+  exec container exec -ti "$NAME" /bin/zsh -l
+}
+
+cmd_stop() {
+  check_container_cli
+
+  if container list 2>/dev/null | grep -q "^$NAME"; then
+    echo "Stopping container..."
+    container stop "$NAME"
+    echo "Container stopped."
+  else
+    echo "Container not running."
+  fi
+}
+
+cmd_destroy() {
+  check_container_cli
+
+  if container list --all 2>/dev/null | grep -q "^$NAME"; then
+    echo "Removing container..."
+    container delete "$NAME"
+    echo "Container removed."
+  else
+    echo "Container does not exist."
+  fi
+}
+
+cmd_status() {
+  check_container_cli
+
+  echo "Container CLI: installed"
+  echo ""
+
+  if container list 2>/dev/null | grep -q "^$NAME"; then
+    echo "Container: running"
+    container inspect "$NAME" 2>/dev/null | head -20
+  elif container list --all 2>/dev/null | grep -q "^$NAME"; then
+    echo "Container: stopped"
+  else
+    echo "Container: not created"
+  fi
+
+  echo ""
+  echo "Image:"
+  container image list 2>/dev/null | grep "$IMAGE" || echo "  (not built)"
+}
+
+cmd_build() {
+  check_container_cli
+
+  echo "Building image..."
+
+  # Find the Dockerfile location
+  SCRIPT_DIR="$(dirname "$0")"
+  if [[ -f "$SCRIPT_DIR/Dockerfile" ]]; then
+    BUILD_DIR="$SCRIPT_DIR"
+  elif [[ -f "./Dockerfile" ]]; then
+    BUILD_DIR="."
+  else
+    echo "Dockerfile not found. Run from the toolkit directory."
+    exit 1
+  fi
+
+  container build --tag "$IMAGE" "$BUILD_DIR"
+  echo ""
+  echo "Image built: $IMAGE"
+}
+
+cmd_logs() {
+  check_container_cli
+
+  if container list --all 2>/dev/null | grep -q "^$NAME"; then
+    container logs "$NAME"
+  else
+    echo "Container does not exist."
+  fi
+}
+
+cmd_help() {
+  echo "devbox-apple - Container lifecycle manager (Apple container)"
+  echo ""
+  echo "Usage: devbox-apple [command]"
+  echo ""
+  echo "Commands:"
+  echo "  (none)    Enter the container (creates if needed)"
+  echo "  stop      Stop the container"
+  echo "  destroy   Remove the container"
+  echo "  status    Show container and image status"
+  echo "  build     Build the container image"
+  echo "  logs      Show container logs"
+  echo "  help      Show this help"
+  echo ""
+  echo "Mounted:"
+  echo "  $WORKSPACE_DIR -> /workspace"
+  echo "  $SHARE_TMP -> /share-tmp"
+  echo "  /var/run/docker.sock (for docker CLI -> OrbStack)"
+  echo ""
+  echo "Ports:"
+  echo "  6443-9999 (mapped 1:1)"
+  echo ""
+  echo "Note: SSH/GPG keys are copied on first creation (not mounted)"
+}
+
+case "${1:-}" in
+  ""|enter)
+    cmd_enter
+    ;;
+  stop)
+    cmd_stop
+    ;;
+  destroy)
+    cmd_destroy
+    ;;
+  status)
+    cmd_status
+    ;;
+  build)
+    cmd_build
+    ;;
+  logs)
+    cmd_logs
+    ;;
+  help|--help|-h)
+    cmd_help
+    ;;
+  *)
+    echo "Unknown command: $1"
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -132,6 +132,12 @@ setup_git_config() {
   fi
 }
 
+# Setup GitHub CLI authentication
+setup_gh_auth() {
+  echo "Authenticating GitHub CLI..."
+  container exec -ti "$NAME" gh auth login --git-protocol ssh --web --skip-ssh-key
+}
+
 cmd_enter() {
   check_container_cli
 
@@ -181,6 +187,9 @@ cmd_enter() {
 
   # Copy git config from host
   setup_git_config
+
+  # Setup GitHub CLI authentication
+  setup_gh_auth
 
   # Enter the container
   exec container exec -ti "$NAME" /bin/zsh -l

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -80,6 +80,21 @@ cmd_enter() {
   # Ensure directories exist
   mkdir -p "$WORKSPACE_DIR" "$SHARE_TMP"
 
+  # Build volume arguments
+  VOLUME_ARGS=(
+    --volume "$WORKSPACE_DIR:/workspace"
+    --volume "$SHARE_TMP:/share-tmp"
+  )
+
+  # Optional: Mount docker.sock if OrbStack/Docker is running
+  if [[ -S /var/run/docker.sock ]]; then
+    echo "✓ Docker socket detected - mounting for Docker CLI access"
+    VOLUME_ARGS+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
+  else
+    echo "ℹ Docker socket not found - Docker CLI won't work inside container"
+    echo "  (Start OrbStack/Docker Desktop to enable)"
+  fi
+
   # Start container in detached mode
   # Note: Apple container uses FIXED allocation per VM (not shared like OrbStack)
   # Default is 1GB RAM / 4 CPUs - too low for dev work, so we override.
@@ -89,9 +104,7 @@ cmd_enter() {
     --memory 8g \
     --cpus 4 \
     --publish 6443-9999:6443-9999 \
-    --volume "$WORKSPACE_DIR:/workspace" \
-    --volume "$SHARE_TMP:/share-tmp" \
-    --volume "/var/run/docker.sock:/var/run/docker.sock" \
+    "${VOLUME_ARGS[@]}" \
     --ssh \
     "$IMAGE"
 
@@ -197,7 +210,7 @@ cmd_help() {
   echo "Mounted:"
   echo "  $WORKSPACE_DIR -> /workspace"
   echo "  $SHARE_TMP -> /share-tmp"
-  echo "  /var/run/docker.sock (for docker CLI -> OrbStack)"
+  echo "  /var/run/docker.sock -> /var/run/docker.sock (if OrbStack/Docker running)"
   echo ""
   echo "Ports:"
   echo "  6443-9999 (mapped 1:1)"

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -101,7 +101,7 @@ cmd_enter() {
     --detach \
     --memory 8g \
     --cpus 4 \
-    --publish 6443-9999:6443-9999 \
+    --publish 10000-19999:10000-19999 \
     "${VOLUME_ARGS[@]}" \
     --ssh \
     "$IMAGE"
@@ -212,7 +212,7 @@ cmd_help() {
   echo "Note: Docker socket mounting not supported (use host Docker CLI)"
   echo ""
   echo "Ports:"
-  echo "  6443-9999 (mapped 1:1)"
+  echo "  10000-19999 (mapped 1:1)"
   echo ""
   echo "Note: SSH/GPG keys are copied on first creation (not mounted)"
 }

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -135,6 +135,9 @@ setup_git_config() {
 # Setup GitHub CLI authentication
 setup_gh_auth() {
   echo "Authenticating GitHub CLI..."
+  echo "Opening browser on your Mac..."
+  open https://github.com/login/device 2>/dev/null &
+  sleep 1
   container exec -ti "$NAME" gh auth login --git-protocol ssh --web --skip-ssh-key
 }
 

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -138,6 +138,9 @@ cmd_destroy() {
   check_container_cli
 
   if container list --all 2>/dev/null | grep -q "^$NAME"; then
+    # Stop first if running
+    cmd_stop
+
     echo "Removing container..."
     container delete "$NAME"
     echo "Container removed."
@@ -193,14 +196,11 @@ cmd_rebuild() {
   echo "Rebuilding container (destroy + build)..."
   echo ""
 
-  # Destroy if exists
-  if container list --all 2>/dev/null | grep -q "^$NAME"; then
-    echo "Removing existing container..."
-    container delete "$NAME"
-    echo ""
-  fi
+  # Destroy existing container (auto-stops if needed)
+  cmd_destroy
+  echo ""
 
-  # Build
+  # Build new image
   cmd_build
 }
 

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -111,6 +111,27 @@ setup_credentials() {
   echo "Credentials setup complete."
 }
 
+# Copy git config from host
+setup_git_config() {
+  local host_email=$(git config --global --get user.email 2>/dev/null)
+  local host_name=$(git config --global --get user.name 2>/dev/null)
+  local host_gpg_key=$(git config --global --get user.signingkey 2>/dev/null)
+
+  if [[ -n "$host_email" ]] && [[ -n "$host_name" ]]; then
+    echo "Copying git config from host..."
+    container exec "$NAME" git config --global user.email "$host_email"
+    container exec "$NAME" git config --global user.name "$host_name"
+    container exec "$NAME" git config --global push.autoSetupRemote true
+
+    if [[ -n "$host_gpg_key" ]]; then
+      container exec "$NAME" git config --global commit.gpgsign true
+      container exec "$NAME" git config --global user.signingkey "$host_gpg_key"
+    fi
+
+    echo "Git configured."
+  fi
+}
+
 cmd_enter() {
   check_container_cli
 
@@ -157,6 +178,9 @@ cmd_enter() {
 
   # Copy credentials on first creation
   setup_credentials
+
+  # Copy git config from host
+  setup_git_config
 
   # Enter the container
   exec container exec -ti "$NAME" /bin/zsh -l

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -76,7 +76,7 @@ copy_credential_dir() {
   local name="$3"
 
   local files=("$src"/*)
-  if [[ -d "$src" ]] && [[ -e "${files[0]}" ]]; then
+  if [[ -d "$src" ]] && [[ -e "${files[1]}" ]]; then
     echo "Copying $name..."
     for f in "${files[@]}"; do
       [[ -f "$f" ]] && cat "$f" | container exec -i "$NAME" tee "$dst/$(basename "$f")" > /dev/null

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -81,19 +81,17 @@ cmd_enter() {
   mkdir -p "$WORKSPACE_DIR" "$SHARE_TMP"
 
   # Build volume arguments
+  # Note: Single file mounting support merged (https://github.com/apple/containerization/pull/487)
+  # but not yet released in container CLI. When available (likely 0.9.0+), uncomment below:
+  #
+  # if [[ -S /var/run/docker.sock ]]; then
+  #   echo "✓ Docker socket detected - mounting for Docker CLI access"
+  #   VOLUME_ARGS+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
+  # fi
   VOLUME_ARGS=(
     --volume "$WORKSPACE_DIR:/workspace"
     --volume "$SHARE_TMP:/share-tmp"
   )
-
-  # Optional: Mount docker.sock if OrbStack/Docker is running
-  if [[ -S /var/run/docker.sock ]]; then
-    echo "✓ Docker socket detected - mounting for Docker CLI access"
-    VOLUME_ARGS+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
-  else
-    echo "ℹ Docker socket not found - Docker CLI won't work inside container"
-    echo "  (Start OrbStack/Docker Desktop to enable)"
-  fi
 
   # Start container in detached mode
   # Note: Apple container uses FIXED allocation per VM (not shared like OrbStack)
@@ -210,7 +208,8 @@ cmd_help() {
   echo "Mounted:"
   echo "  $WORKSPACE_DIR -> /workspace"
   echo "  $SHARE_TMP -> /share-tmp"
-  echo "  /var/run/docker.sock -> /var/run/docker.sock (if OrbStack/Docker running)"
+  echo ""
+  echo "Note: Docker socket mounting not supported (use host Docker CLI)"
   echo ""
   echo "Ports:"
   echo "  6443-9999 (mapped 1:1)"

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -190,21 +190,33 @@ cmd_build() {
   # Check current builder status
   local current_builder=$(container builder status 2>/dev/null | grep -E "^buildkit" || echo "")
   if [[ -n "$current_builder" ]]; then
-    # Builder exists, show actual config
-    local current_cpus=$(echo "$current_builder" | awk '{print $6}')
-    local current_mem_mb=$(echo "$current_builder" | awk '{print $7}')
+    # Builder exists - use it (respect manual configuration)
+    local current_cpus=$(echo "$current_builder" | awk '{print $5}')
+    local current_mem_mb=$(echo "$current_builder" | awk '{print $6}')
     local current_mem_gb=$((current_mem_mb / 1024))
     echo "Using existing builder: ${current_cpus} CPUs / ${current_mem_gb}g"
 
-    # Check if it matches script defaults
+    # Check for mismatch with script defaults
     local target_mem_mb=$((${BUILDER_MEMORY%g} * 1024))
     if [[ "$current_cpus" != "$BUILDER_CPUS" ]] || [[ "$current_mem_mb" != "$target_mem_mb" ]]; then
-      echo "(Script default: ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY} - use 'devbox-apple builder-configure' to reconfigure)"
+      echo ""
+      echo "⚠️  WARNING: Builder config doesn't match script defaults"
+      echo "   Current:  ${current_cpus} CPUs / ${current_mem_gb}g"
+      echo "   Default:  ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY}"
+      echo ""
+      echo "Build may be slower/faster than expected."
+      echo "To use defaults, run: devbox-apple builder-configure"
+      echo ""
+      read -p "Continue with current builder? [y/N] " -n 1 -r
+      echo ""
+      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Build cancelled."
+        exit 0
+      fi
     fi
   else
-    # No builder, will create with script defaults
-    echo "Builder configuration: ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY}"
-    echo "Starting builder..."
+    # No builder - create with script defaults
+    echo "No builder found, creating with defaults: ${BUILDER_CPUS} CPUs / ${BUILDER_MEMORY}"
     container builder start --cpus "$BUILDER_CPUS" --memory "$BUILDER_MEMORY"
     sleep 2
   fi

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -163,9 +163,14 @@ cmd_enter() {
   )
 
   # Mount Docker socket if available on host
+  # /var/run/docker.sock is typically a symlink (OrbStack: ~/.orbstack/run/docker.sock,
+  # Docker Desktop: ~/.docker/run/docker.sock). Apple container's single-file mount
+  # cannot follow the symlink, so resolve to the real path before mounting.
   if [[ -S /var/run/docker.sock ]]; then
-    echo "Docker socket detected - mounting for Docker CLI access"
-    volume_args+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
+    local docker_sock_src
+    docker_sock_src=$(readlink -f /var/run/docker.sock 2>/dev/null || echo /var/run/docker.sock)
+    echo "Docker socket detected at $docker_sock_src - mounting for Docker CLI access"
+    volume_args+=(--volume "$docker_sock_src:/var/run/docker.sock")
   fi
 
   # Start container in detached mode

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -40,12 +40,40 @@ CONTAINER_MEMORY="8g"
 BUILDER_CPUS=8
 BUILDER_MEMORY="8g"
 
+# Network configuration (see setup_network for the why)
+NETWORK_NAME="devbox-apple-net"
+NETWORK_SUBNET="192.168.100.0/24"
+
 check_container_cli() {
   if ! command -v container &>/dev/null; then
     echo "Apple container CLI not found."
     echo "Requires macOS 26+ with container CLI installed."
     echo "See: https://github.com/apple/container"
     exit 1
+  fi
+}
+
+# Ensure an IPv4-only network exists for the container.
+#
+# Apple's `container` runtime (apple/container) assigns an IPv6 ULA to eth0
+# via SLAAC but does NOT install an IPv6 default route — NAT66 is not yet
+# implemented (see https://github.com/apple/container/issues/1034). Any IPv6
+# egress outside the local /64 returns ENETUNREACH. Tools with weak Happy
+# Eyeballs fallback (notably Node's undici/fetch, which powers corepack,
+# npm, pnpm) pick the IPv6 candidate and hang to timeout instead of
+# retrying over IPv4. curl is fine; node fetch is not.
+#
+# Fix: run the container on a network created without --subnet-v6, which
+# makes apple/container skip IPv6 assignment entirely. This mirrors how
+# OrbStack's eth0 has no IPv6 globals at all, so getaddrinfo never returns
+# AAAA candidates (RFC 6724 source-address selection).
+#
+# Remove this and revert to the default network once apple/container ships
+# working NAT66 / IPv6 egress.
+setup_network() {
+  if ! container network list --quiet 2>/dev/null | grep -q "^${NETWORK_NAME}$"; then
+    echo "Creating IPv4-only network: ${NETWORK_NAME} (${NETWORK_SUBNET})"
+    container network create "${NETWORK_NAME}" --subnet "${NETWORK_SUBNET}"
   fi
 }
 
@@ -153,6 +181,9 @@ cmd_enter() {
   # Container doesn't exist, create and start it
   echo "Creating container..."
 
+  # Ensure IPv4-only network exists (works around apple/container IPv6 egress bug)
+  setup_network
+
   # Ensure directories exist
   mkdir -p "$WORKSPACE_DIR" "$SHARE_TMP"
 
@@ -181,6 +212,7 @@ cmd_enter() {
     --detach \
     --memory "$CONTAINER_MEMORY" \
     --cpus "$CONTAINER_CPUS" \
+    --network "$NETWORK_NAME" \
     --publish 10000-19999:10000-19999 \
     "${volume_args[@]}" \
     --ssh \

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -40,9 +40,19 @@ CONTAINER_MEMORY="8g"
 BUILDER_CPUS=8
 BUILDER_MEMORY="8g"
 
-# Network configuration (see setup_network for the why)
-NETWORK_NAME="devbox-apple-net"
-NETWORK_SUBNET="192.168.100.0/24"
+# Xcode MCP bridge (xcodebuildmcp on Xcode 16+). Lives under SHARE_TMP so
+# cleanup is colocated with the rest of devbox state. Lifecycle is tied to
+# the container via start_xcode_bridge / stop_xcode_bridge — there is no
+# always-on listener.
+XCODE_MCP_SOCKET="$SHARE_TMP/xcode-mcp.sock"
+XCODE_MCP_PIDFILE="$SHARE_TMP/.xcode-mcp.pid"
+XCODE_MCP_LOG="$SHARE_TMP/.xcode-mcp.log"
+# Scope xcodebuildmcp to iOS+macOS-relevant workflows (see
+# https://www.xcodebuildmcp.com/docs/workflows for the full list of 15).
+# Add `xcode-ide` to enable Xcode 26.3+ IDE-only features (preview rendering,
+# Issue Navigator) — that workflow proxies xcrun mcpbridge and requires the
+# Xcode Tools toggle in Xcode → Settings → Intelligence.
+XCODEBUILDMCP_WORKFLOWS="simulator,macos,session-management,project-discovery,device,debugging,swift-package,utilities,ui-automation"
 
 check_container_cli() {
   if ! command -v container &>/dev/null; then
@@ -53,29 +63,10 @@ check_container_cli() {
   fi
 }
 
-# Ensure an IPv4-only network exists for the container.
-#
-# Apple's `container` runtime (apple/container) assigns an IPv6 ULA to eth0
-# via SLAAC but does NOT install an IPv6 default route — NAT66 is not yet
-# implemented (see https://github.com/apple/container/issues/1034). Any IPv6
-# egress outside the local /64 returns ENETUNREACH. Tools with weak Happy
-# Eyeballs fallback (notably Node's undici/fetch, which powers corepack,
-# npm, pnpm) pick the IPv6 candidate and hang to timeout instead of
-# retrying over IPv4. curl is fine; node fetch is not.
-#
-# Fix: run the container on a network created without --subnet-v6, which
-# makes apple/container skip IPv6 assignment entirely. This mirrors how
-# OrbStack's eth0 has no IPv6 globals at all, so getaddrinfo never returns
-# AAAA candidates (RFC 6724 source-address selection).
-#
-# Remove this and revert to the default network once apple/container ships
-# working NAT66 / IPv6 egress.
-setup_network() {
-  if ! container network list --quiet 2>/dev/null | grep -q "^${NETWORK_NAME}$"; then
-    echo "Creating IPv4-only network: ${NETWORK_NAME} (${NETWORK_SUBNET})"
-    container network create "${NETWORK_NAME}" --subnet "${NETWORK_SUBNET}"
-  fi
-}
+# Networking note: this container runs on apple/container's default network.
+# The container's IP is directly routable from the Mac, so we don't need a
+# --publish range — `http://<container-ip>:<port>` Just Works for anything
+# bound to 0.0.0.0 inside the container.
 
 # Helper: Check if container is running
 container_is_running() {
@@ -85,6 +76,27 @@ container_is_running() {
 # Helper: Check if container exists (running or stopped)
 container_exists() {
   container list --all 2>/dev/null | grep -q "^$NAME"
+}
+
+# Helper: Wait until the container's in-guest agent is accepting execs.
+#
+# `container run --detach` and `container start` both return as soon as the
+# Linux VM begins booting, not when the agent is ready to handle exec. Hitting
+# the runtime in that window can fail outright or — worse — wedge it via the
+# upstream apple/container XPC race (#576/#167). Probe with a no-op exec.
+wait_for_container_ready() {
+  local max_wait=10 elapsed=0
+  echo -n "Waiting for container..."
+  while ! container exec "$NAME" true >/dev/null 2>&1; do
+    if (( elapsed >= max_wait )); then
+      echo " timed out after ${max_wait}s" >&2
+      return 1
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+    echo -n "."
+  done
+  echo " ready (${elapsed}s)"
 }
 
 # Helper: Check if builder exists
@@ -101,63 +113,132 @@ get_builder_resources() {
   echo "$cpus $mem_gb"
 }
 
-# Helper: Copy credential directory into container
-copy_credential_dir() {
-  local src="$1"
-  local dst="$2"
-  local name="$3"
-
-  local files=("$src"/*)
-  if [[ -d "$src" ]] && [[ -e "${files[1]}" ]]; then
-    echo "Copying $name..."
-
-    for f in "${files[@]}"; do
-      if [[ -f "$f" ]]; then
-        cat "$f" | container exec -i "$NAME" tee "$dst/$(basename "$f")" > /dev/null
-      elif [[ -d "$f" ]]; then
-        local dirname="$(basename "$f")"
-        container exec "$NAME" mkdir -p "$dst/$dirname"
-        tar -C "$src/$dirname" -cf - . 2>/dev/null | container exec -i "$NAME" tar -C "$dst/$dirname" -xf - 2>/dev/null || true
-      fi
-    done
-
-    container exec "$NAME" sh -c "chmod 700 '$dst' && find '$dst' -type f -exec chmod 600 {} +"
-  else
-    echo "  (no $name found, skipping)"
+# Helper: Stage one credential dir under $SHARE_TMP for the in-container copy.
+#
+# `rsync -a` is `-rlptgoD`; we drop -D (devices/specials) because we never
+# want to recreate macOS Unix sockets (gpg-agent's S.gpg-agent, 1Password's
+# ~/.ssh/agent/s.*, etc.) inside the Linux VM. The in-guest agents create
+# their own socket paths, and a host-side socket file confuses the
+# in-container `cp -a` ("No such file or directory" on perms preserve).
+#
+# We also exclude `*.lock`: GPG leaves lock files behind on the host
+# (e.g. ~/.gnupg/public-keys.d/pubring.db.lock) that are stale from the
+# guest's perspective — copying them in causes "database is locked" errors
+# on the first in-container gpg invocation.
+stage_creds_subdir() {
+  local src="$1" dst="$2" label="$3"
+  if [[ ! -d "$src" ]] || [[ -z "$(ls -A "$src" 2>/dev/null)" ]]; then
+    echo "  (no $label found, skipping)"
+    return 1
   fi
+  echo "Staging $label..."
+  mkdir -p "$dst"
+  rsync -a --no-D --exclude='*.lock' "$src/" "$dst/"
 }
 
-# Copy SSH and GPG keys into container (one-time setup)
+# Copy SSH and GPG keys into container (one-time setup).
+#
+# We stage credentials through the existing /share-tmp bind mount and do the
+# in-container copy with a single, non-piped `container exec`. The previous
+# approach streamed each file through `container exec -i ... tee`, which is
+# the apple/container code path most prone to wedging the runtime: a race in
+# the apiserver↔runtime XPC stdin-EOF callback (upstream #576 / #167) leaves
+# the runtime in a state where every subsequent stop/rm/exec hangs forever,
+# only recoverable by `kill -9` on container-runtime-linux. Streaming N
+# credential files rolled the dice on that race once per file; this drops it
+# to one non-piped exec call.
 setup_credentials() {
-  # Create directories
-  container exec "$NAME" mkdir -p /root/.ssh /root/.gnupg
+  local stage="$SHARE_TMP/.creds"
+  rm -rf "$stage"
+  mkdir -p "$stage"
 
-  # Copy credentials
-  copy_credential_dir "$SSH_DIR" "/root/.ssh" "SSH keys"
-  copy_credential_dir "$GNUPG_DIR" "/root/.gnupg" "GPG keys"
+  local copied=0
+  stage_creds_subdir "$SSH_DIR"   "$stage/ssh"   "SSH keys" && copied=1
+  stage_creds_subdir "$GNUPG_DIR" "$stage/gnupg" "GPG keys" && copied=1
+
+  if [[ $copied -eq 0 ]]; then
+    rm -rf "$stage"
+    return
+  fi
+
+  # Single non-piped exec: copy from the bind-mounted stage dir, lock down
+  # perms, then rm the stage dir. /share-tmp is a bind mount of $SHARE_TMP,
+  # so the rm also cleans the host-side staging copy.
+  container exec "$NAME" sh -c '
+    set -e
+    for sub in ssh gnupg; do
+      if [ -d "/share-tmp/.creds/$sub" ]; then
+        mkdir -p "/root/.$sub"
+        cp -a "/share-tmp/.creds/$sub/." "/root/.$sub/"
+        chmod 700 "/root/.$sub"
+        find "/root/.$sub" -type f -exec chmod 600 {} +
+      fi
+    done
+    rm -rf /share-tmp/.creds
+  '
 
   echo "Credentials setup complete."
 }
 
-# Copy git config from host
+# Copy git config from host.
+#
+# Single-exec design (mirrors setup_credentials): one `container exec` call,
+# values passed via -e env vars so we don't string-interpolate user input into
+# a shell script. Each apiserver roundtrip is a fresh chance to hit an
+# apple/container XPC race (upstream #167) — fewer is strictly better.
 setup_git_config() {
-  local host_email=$(git config --global --get user.email 2>/dev/null)
-  local host_name=$(git config --global --get user.name 2>/dev/null)
-  local host_gpg_key=$(git config --global --get user.signingkey 2>/dev/null)
+  local host_email host_name host_gpg_key
+  host_email=$(git config --global --get user.email 2>/dev/null)
+  host_name=$(git config --global --get user.name 2>/dev/null)
+  host_gpg_key=$(git config --global --get user.signingkey 2>/dev/null)
 
-  if [[ -n "$host_email" ]] && [[ -n "$host_name" ]]; then
-    echo "Copying git config from host..."
-    container exec "$NAME" git config --global user.email "$host_email"
-    container exec "$NAME" git config --global user.name "$host_name"
-    container exec "$NAME" git config --global push.autoSetupRemote true
-
-    if [[ -n "$host_gpg_key" ]]; then
-      container exec "$NAME" git config --global commit.gpgsign true
-      container exec "$NAME" git config --global user.signingkey "$host_gpg_key"
-    fi
-
-    echo "Git configured."
+  if [[ -z "$host_email" || -z "$host_name" ]]; then
+    return
   fi
+
+  echo "Copying git config from host..."
+  container exec \
+    -e "HOST_EMAIL=$host_email" \
+    -e "HOST_NAME=$host_name" \
+    -e "HOST_GPG_KEY=$host_gpg_key" \
+    "$NAME" \
+    sh -c '
+      git config --global user.email "$HOST_EMAIL"
+      git config --global user.name "$HOST_NAME"
+      git config --global push.autoSetupRemote true
+      if [ -n "$HOST_GPG_KEY" ]; then
+        git config --global commit.gpgsign true
+        git config --global user.signingkey "$HOST_GPG_KEY"
+      fi
+    '
+  echo "Git configured."
+}
+
+# Replace the image's empty /workspace directory with a symlink to the real
+# bind-mount at $WORKSPACE_DIR.
+#
+# Why: xcodebuildmcp runs on the macOS host and only understands host-side
+# paths. By making the in-container mount live at the same absolute path as
+# the host, every path Claude reads from `pwd`, `find`, etc. is already a
+# valid host path — no per-call translation. /workspace stays as a typing
+# shortcut for humans.
+#
+# Why this needs to run at first creation: the Dockerfile sets `WORKDIR
+# /workspace`, which materializes an empty directory in the image. The
+# bind mount lives elsewhere now ($WORKSPACE_DIR), so we rm the leftover
+# placeholder and replace it with a symlink.
+#
+# Single non-piped exec, mirroring the setup_credentials pattern (see comment
+# there re: apple/container XPC race #167).
+setup_workspace_alias() {
+  echo "Symlinking /workspace -> $WORKSPACE_DIR..."
+  container exec \
+    -e "WORKSPACE_DIR=$WORKSPACE_DIR" \
+    "$NAME" \
+    sh -c '
+      rm -rf /workspace
+      ln -sfn "$WORKSPACE_DIR" /workspace
+    '
 }
 
 # Setup GitHub CLI authentication
@@ -167,6 +248,78 @@ setup_gh_auth() {
   open https://github.com/login/device 2>/dev/null &
   sleep 1
   container exec -ti "$NAME" gh auth login --git-protocol ssh --web --skip-ssh-key
+}
+
+# Start the Xcode MCP bridge on the host: a backgrounded socat listener that
+# spawns `xcodebuildmcp mcp` per connection. Coupled to container lifecycle —
+# the matching stop_xcode_bridge tears it down on `stop`/`destroy`.
+# Hard-fails if prereqs are missing rather than silently skipping — the
+# in-container MCP server is pre-registered and would otherwise show up as
+# unhealthy with no obvious cause.
+start_xcode_bridge() {
+  if ! command -v socat &>/dev/null; then
+    echo "Error: socat not found on host." >&2
+    echo "Install with: brew install socat" >&2
+    exit 1
+  fi
+  if ! command -v xcodebuildmcp &>/dev/null; then
+    echo "Error: xcodebuildmcp not found on host." >&2
+    echo "Install with: brew install getsentry/xcodebuildmcp/xcodebuildmcp" >&2
+    exit 1
+  fi
+
+  # Reap any stale state (orphaned PID file or socket from a prior unclean exit)
+  stop_xcode_bridge
+
+  mkdir -p "$(dirname "$XCODE_MCP_SOCKET")"
+
+  echo "Starting Xcode MCP bridge listener..."
+  # Supervisor loop instead of socat's `fork`. Without fork, socat handles
+  # exactly one connection at a time — and on connection close, both socat
+  # and its EXEC'd xcodebuildmcp child exit cleanly via SIGTERM propagation.
+  # The while loop then re-listens for the next Claude session. Net effect:
+  # at most one xcodebuildmcp alive at any moment, no orphan accumulation,
+  # no idle-timeout workaround needed.
+  nohup env \
+      XCODEBUILDMCP_ENABLED_WORKFLOWS="$XCODEBUILDMCP_WORKFLOWS" \
+      XCODEBUILDMCP_SENTRY_DISABLED=true \
+      XCODE_MCP_SOCKET="$XCODE_MCP_SOCKET" \
+    bash -c '
+      while socat "UNIX-LISTEN:${XCODE_MCP_SOCKET},mode=600" "EXEC:xcodebuildmcp mcp"; do :; done
+    ' > "$XCODE_MCP_LOG" 2>&1 &
+  echo $! > "$XCODE_MCP_PIDFILE"
+
+  # Wait for socat to actually bind the socket before returning. The supervisor
+  # is nohup'd, so there's a small async window (bash startup → loop → socat
+  # bind) during which the socket file doesn't exist. Without this wait,
+  # `container start`/`container run` immediately after can fail with:
+  #     Error: mount source path '$XCODE_MCP_SOCKET' does not exist
+  local attempts=0 max_attempts=50
+  while [[ ! -S "$XCODE_MCP_SOCKET" ]]; do
+    if (( attempts >= max_attempts )); then
+      echo "Error: Xcode MCP bridge socket did not appear within 5s." >&2
+      echo "Check $XCODE_MCP_LOG for details." >&2
+      exit 1
+    fi
+    sleep 0.1
+    attempts=$((attempts + 1))
+  done
+}
+
+stop_xcode_bridge() {
+  if [[ -f "$XCODE_MCP_PIDFILE" ]]; then
+    local pid
+    pid=$(cat "$XCODE_MCP_PIDFILE" 2>/dev/null || echo "")
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      # Kill the supervisor first so the loop stops re-spawning socat.
+      # Then kill any in-flight socat child (which on SIGTERM cascades to
+      # xcodebuildmcp via socat's EXEC shutdown handler).
+      kill "$pid" 2>/dev/null || true
+      pkill -P "$pid" 2>/dev/null || true
+    fi
+    rm -f "$XCODE_MCP_PIDFILE"
+  fi
+  rm -f "$XCODE_MCP_SOCKET"
 }
 
 cmd_enter() {
@@ -181,35 +334,61 @@ cmd_enter() {
   # Container exists but is stopped — start it and exec in
   if container_exists; then
     echo "Starting stopped container..."
+    # Restart the bridge so the in-container socket mount has something to
+    # connect to. The volume mount itself was baked in at create time.
+    start_xcode_bridge
     container start "$NAME"
+    wait_for_container_ready || exit 1
     exec container exec -ti "$NAME" /bin/zsh -l
   fi
 
   # Container doesn't exist, create and start it
   echo "Creating container..."
 
-  # Ensure IPv4-only network exists (works around apple/container IPv6 egress bug)
-  setup_network
-
   # Ensure directories exist
   mkdir -p "$WORKSPACE_DIR" "$SHARE_TMP"
 
-  # Build volume arguments
+  # Build volume arguments.
+  # Workspace is bind-mounted at the SAME absolute path as on the host so that
+  # paths Claude passes to host-side MCP tools (xcodebuildmcp) resolve
+  # identically on both sides. /workspace remains usable as a shorthand via a
+  # symlink set up in setup_workspace_alias.
   local volume_args=(
-    --volume "$WORKSPACE_DIR:/workspace"
+    --volume "$WORKSPACE_DIR:$WORKSPACE_DIR"
     --volume "$SHARE_TMP:/share-tmp"
   )
 
-  # Mount Docker socket if available on host
-  # /var/run/docker.sock is typically a symlink (OrbStack: ~/.orbstack/run/docker.sock,
-  # Docker Desktop: ~/.docker/run/docker.sock). Apple container's single-file mount
-  # cannot follow the symlink, so resolve to the real path before mounting.
-  if [[ -S /var/run/docker.sock ]]; then
-    local docker_sock_src
-    docker_sock_src=$(readlink -f /var/run/docker.sock 2>/dev/null || echo /var/run/docker.sock)
-    echo "Docker socket detected at $docker_sock_src - mounting for Docker CLI access"
-    volume_args+=(--volume "$docker_sock_src:/var/run/docker.sock")
+  # Mount Docker socket. /var/run/docker.sock is typically a symlink (OrbStack:
+  # ~/.orbstack/run/docker.sock, Docker Desktop: ~/.docker/run/docker.sock).
+  # Apple container's single-file mount cannot follow the symlink, so resolve
+  # to the real path before mounting.
+  #
+  # Mandatory at create time: mounts are baked in by `container run` and cannot
+  # be added later. Failing fast here is much friendlier than discovering it
+  # mid-session via "no such file or directory" on docker.sock. Resume path
+  # (cmd_enter for an existing container) does not re-check — if Docker is down
+  # when resuming, you still get into the container; `docker` calls just fail
+  # until you restart Docker on the Mac.
+  if [[ ! -S /var/run/docker.sock ]]; then
+    echo "" >&2
+    echo "Error: Docker socket not found at /var/run/docker.sock on host." >&2
+    echo "       Docker (OrbStack or Docker Desktop) must be running before" >&2
+    echo "       creating the container — the mount is baked in at create time" >&2
+    echo "       and cannot be patched up later." >&2
+    echo "" >&2
+    echo "       Start Docker on the Mac, then re-run: devbox-apple" >&2
+    echo "" >&2
+    exit 1
   fi
+  local docker_sock_src
+  docker_sock_src=$(readlink -f /var/run/docker.sock 2>/dev/null || echo /var/run/docker.sock)
+  echo "Docker socket detected at $docker_sock_src - mounting for Docker CLI access"
+  volume_args+=(--volume "$docker_sock_src:/var/run/docker.sock")
+
+  # Start the Xcode MCP bridge on the host (hard-fails if prereqs missing)
+  # and mount its socket into the container.
+  start_xcode_bridge
+  volume_args+=(--volume "$XCODE_MCP_SOCKET:/var/run/xcode-mcp.sock")
 
   # Start container in detached mode
   # Note: Apple container uses FIXED allocation per VM (not shared like OrbStack)
@@ -219,20 +398,20 @@ cmd_enter() {
     --detach \
     --memory "$CONTAINER_MEMORY" \
     --cpus "$CONTAINER_CPUS" \
-    --network "$NETWORK_NAME" \
-    --publish 10000-19999:10000-19999 \
     "${volume_args[@]}" \
     --ssh \
     "$IMAGE"
 
-  # Wait for container to be ready
-  sleep 2
+  wait_for_container_ready || exit 1
 
   # Copy credentials on first creation
   setup_credentials
 
   # Copy git config from host
   setup_git_config
+
+  # Mirror host workspace path inside container (for host-side MCP tools like xcodebuildmcp)
+  setup_workspace_alias
 
   # Setup GitHub CLI authentication
   setup_gh_auth
@@ -251,6 +430,9 @@ cmd_stop() {
   else
     echo "Container not running."
   fi
+
+  # Always tear down the bridge — idempotent, reaps orphans from external stops too
+  stop_xcode_bridge
 }
 
 cmd_destroy() {
@@ -263,6 +445,8 @@ cmd_destroy() {
   else
     echo "Container does not exist."
   fi
+
+  stop_xcode_bridge
 }
 
 cmd_status() {
@@ -273,7 +457,15 @@ cmd_status() {
 
   if container_is_running; then
     echo "Container: running"
-    container inspect "$NAME" 2>/dev/null | head -20
+    local ip
+    ip=$(container inspect "$NAME" 2>/dev/null \
+      | grep -oE '"ipv4Address":"[^/]+' \
+      | head -1 \
+      | cut -d'"' -f4)
+    if [[ -n "$ip" ]]; then
+      echo "IP:        $ip"
+      echo "           (services bound to 0.0.0.0 in-container reachable at http://$ip:<port>)"
+    fi
   elif container_exists; then
     echo "Container: stopped"
   else
@@ -495,12 +687,16 @@ cmd_help() {
   echo "  Auto-remove after build: yes (use --keep-builder to prevent)"
   echo ""
   echo "Mounted:"
-  echo "  $WORKSPACE_DIR -> /workspace"
+  echo "  $WORKSPACE_DIR -> $WORKSPACE_DIR (mirrored path; /workspace symlinks here)"
   echo "  $SHARE_TMP -> /share-tmp"
   echo "  /var/run/docker.sock -> /var/run/docker.sock (if available)"
+  echo "  $XCODE_MCP_SOCKET -> /var/run/xcode-mcp.sock (xcodebuildmcp on host)"
   echo ""
-  echo "Ports:"
-  echo "  10000-19999 (mapped 1:1)"
+  echo "Networking:"
+  echo "  Container is on apple/container's default network."
+  echo "  Services bound to 0.0.0.0 inside the container are reachable from"
+  echo "  the Mac at http://<container-ip>:<port>. Find the IP via:"
+  echo "    devbox-apple status   (or: container inspect $NAME)"
   echo ""
   echo "Note: SSH/GPG keys are copied on first creation (not mounted)"
 }

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -157,17 +157,16 @@ cmd_enter() {
   mkdir -p "$WORKSPACE_DIR" "$SHARE_TMP"
 
   # Build volume arguments
-  # Note: Single file mounting support merged (https://github.com/apple/containerization/pull/487)
-  # but not yet released in container CLI. When available (likely 0.9.0+), uncomment below:
-  #
-  # if [[ -S /var/run/docker.sock ]]; then
-  #   echo "✓ Docker socket detected - mounting for Docker CLI access"
-  #   VOLUME_ARGS+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
-  # fi
   local volume_args=(
     --volume "$WORKSPACE_DIR:/workspace"
     --volume "$SHARE_TMP:/share-tmp"
   )
+
+  # Mount Docker socket if available on host
+  if [[ -S /var/run/docker.sock ]]; then
+    echo "Docker socket detected - mounting for Docker CLI access"
+    volume_args+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
+  fi
 
   # Start container in detached mode
   # Note: Apple container uses FIXED allocation per VM (not shared like OrbStack)
@@ -441,8 +440,7 @@ cmd_help() {
   echo "Mounted:"
   echo "  $WORKSPACE_DIR -> /workspace"
   echo "  $SHARE_TMP -> /share-tmp"
-  echo ""
-  echo "Note: Docker socket mounting not supported yet (coming soon)"
+  echo "  /var/run/docker.sock -> /var/run/docker.sock (if available)"
   echo ""
   echo "Ports:"
   echo "  10000-19999 (mapped 1:1)"

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -343,10 +343,18 @@ cmd_build() {
     exit 1
   fi
 
-  # Build the image
-  container build --tag "$IMAGE" "$build_dir"
+  # Capture the source commit for build provenance.
+  # describe --always --dirty gives a tag if available, else short SHA, with
+  # `-dirty` suffix when the working tree has uncommitted changes.
+  local git_commit
+  git_commit=$(git -C "$build_dir" describe --always --dirty --abbrev=12 2>/dev/null || echo unknown)
+  echo "Source commit: $git_commit"
   echo ""
-  echo "Image built: $IMAGE"
+
+  # Build the image
+  container build --build-arg "GIT_COMMIT=${git_commit}" --tag "$IMAGE" "$build_dir"
+  echo ""
+  echo "Image built: $IMAGE (commit: $git_commit)"
 
   # Auto-remove builder unless --keep-builder flag
   if [[ "$keep_builder" == false ]]; then

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -25,7 +25,7 @@ NAME="devbox-apple"
 IMAGE="devbox-apple:latest"
 
 # Paths (adjust to your setup)
-WORKSPACE_DIR="$HOME/workspaces/toolkit-workspace"
+WORKSPACE_DIR="$HOME/workspaces/applecntr-workspace"
 SHARE_TMP="$HOME/tmp/dev-toolkit"
 
 # Source directories for initial copy (not mounted)

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -294,15 +294,20 @@ cmd_build() {
 
   echo ""
 
-  # Find the Dockerfile location
+  # Find the Dockerfile location.
+  # Reject any Dockerfile that doesn't extend the base toolkit image — otherwise
+  # running `devbox-apple build` from a directory containing the base Dockerfile
+  # (e.g. the repo root) would silently build the wrong image.
   local script_dir="$(dirname "$0")"
   local build_dir
-  if [[ -f "$script_dir/Dockerfile" ]]; then
+  if [[ -f "$script_dir/Dockerfile" ]] && grep -q "^FROM portainer/dev-toolkit" "$script_dir/Dockerfile"; then
     build_dir="$script_dir"
-  elif [[ -f "./Dockerfile" ]]; then
+  elif [[ -f "./Dockerfile" ]] && grep -q "^FROM portainer/dev-toolkit" "./Dockerfile"; then
     build_dir="."
   else
-    echo "Dockerfile not found. Run from the toolkit directory."
+    echo "Error: alapenna-container Dockerfile not found." >&2
+    echo "Run \`devbox-apple build\` from user-toolkits/alapenna-container/," >&2
+    echo "or \`make alapenna-container\` from the repo root." >&2
     exit 1
   fi
 

--- a/user-toolkits/alapenna-container/devbox-apple
+++ b/user-toolkits/alapenna-container/devbox-apple
@@ -178,6 +178,13 @@ cmd_enter() {
     exec container exec -ti "$NAME" /bin/zsh -l
   fi
 
+  # Container exists but is stopped — start it and exec in
+  if container_exists; then
+    echo "Starting stopped container..."
+    container start "$NAME"
+    exec container exec -ti "$NAME" /bin/zsh -l
+  fi
+
   # Container doesn't exist, create and start it
   echo "Creating container..."
 

--- a/user-toolkits/alapenna-container/scripts/ccm
+++ b/user-toolkits/alapenna-container/scripts/ccm
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# ccm - Claude commit message generator
+# Stages all changes, then generates a commit message using Claude
+
+set -e
+
+# Max diff size in bytes before falling back to manual input
+MAX_DIFF_SIZE=${CCM_MAX_DIFF_SIZE:-300000}
+
+# Check for any changes (staged or unstaged)
+if [[ -z "$(git status --porcelain)" ]]; then
+  echo "No changes to commit."
+  exit 1
+fi
+
+# Stage everything
+git add -A
+
+diff=$(git diff --cached)
+diff_size=${#diff}
+
+prompt='Write a commit message for this diff following this exact format:
+
+<subject line: imperative mood, describes the overall change, no prefix like "feat:" or "fix:">
+
+- <bullet point: specific change, starts with verb>
+- <bullet point: specific change, starts with verb>
+- ...
+
+Example:
+Update UI design spec with Step 6 implementation
+
+- Rename "Review & Deploy" to "Review & Install" throughout
+- Document actual implementation details
+- Add slide-out drawer specification
+
+Rules:
+- Subject line: imperative mood ("Add X" not "Added X"), max 72 chars
+- Body: 3-8 bullet points, each starting with a verb (Add, Fix, Update, Remove, Refactor, Extract, etc.)
+- No trailing periods on bullets
+- Output ONLY the message, no markdown fences or extra text'
+
+# Check if diff exceeds size limit
+if [[ $diff_size -gt $MAX_DIFF_SIZE ]]; then
+  echo "Diff too large for Claude ($(numfmt --to=iec $diff_size) > $(numfmt --to=iec $MAX_DIFF_SIZE))"
+  echo ""
+  git diff --cached --stat
+  echo ""
+  read -p "Enter commit message (or 'q' to abort): " manual_msg
+  if [[ "$manual_msg" == "q" || -z "$manual_msg" ]]; then
+    echo "Aborted (changes remain staged)."
+    exit 0
+  fi
+  msg="$manual_msg"
+  echo ""
+  read -p "Commit? [Y/n/e/u] " choice
+else
+  msg=$(echo "$diff" | claude -p "$prompt")
+  echo -e "\nSuggested:\n$msg\n"
+  read -p "Commit? [Y/n/e/u] " choice
+fi
+
+prompt_push() {
+  read -p "Push? [Y/n] " push_choice
+  case "${push_choice:-y}" in
+    n|N) echo "Skipped push." ;;
+    *) git push ;;
+  esac
+}
+
+case "${choice:-y}" in
+  n|N) echo "Aborted (changes remain staged)." ;;
+  e|E) git commit -e -m "$msg" && prompt_push ;;
+  u|U) git reset HEAD >/dev/null; echo "Unstaged all changes." ;;
+  *)   git commit -m "$msg" && prompt_push ;;
+esac

--- a/user-toolkits/alapenna-container/scripts/ccm
+++ b/user-toolkits/alapenna-container/scripts/ccm
@@ -4,6 +4,12 @@
 
 set -e
 
+# Check for claude CLI
+if ! command -v claude &>/dev/null; then
+  echo "Error: claude CLI not found. Install from https://claude.ai/code"
+  exit 1
+fi
+
 # Max diff size in bytes before falling back to manual input
 MAX_DIFF_SIZE=${CCM_MAX_DIFF_SIZE:-300000}
 

--- a/user-toolkits/alapenna-container/scripts/entrypoint.sh
+++ b/user-toolkits/alapenna-container/scripts/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Container entrypoint - runs on every container start
+
+# Clean tmp files older than 8 hours to prevent disk bloat from builds
+find /tmp -mindepth 1 -mmin +480 -exec rm -rf {} \; 2>/dev/null || true
+
+# Keep container running
+exec sleep infinity

--- a/user-toolkits/alapenna-ghostty/Dockerfile
+++ b/user-toolkits/alapenna-ghostty/Dockerfile
@@ -158,8 +158,8 @@ RUN claude plugin marketplace add jarrodwatts/claude-hud \
     && claude plugin install gopls-lsp@claude-plugins-official
 
 # Claude Code config files
-RUN mkdir -p /root/.claude/plugins/claude-hud \
-    && cat > /root/.claude/plugins/claude-hud/config.json <<'EOF'
+RUN mkdir -p $HOME/.claude/plugins/claude-hud \
+    && cat > $HOME/.claude/plugins/claude-hud/config.json <<'EOF'
 {
   "layout": "default",
   "display": {
@@ -181,7 +181,7 @@ RUN mkdir -p /root/.claude/plugins/claude-hud \
 }
 EOF
 
-RUN cat > /root/.claude/settings.json <<'EOF'
+RUN cat > $HOME/.claude/settings.json <<'EOF'
 {
   "statusLine": {
     "type": "command",
@@ -195,7 +195,8 @@ RUN cat > /root/.claude/settings.json <<'EOF'
   "permissions": {
     "deny": [
       "Read(**/.env*)",
-      "Read(~/.ssh/**)"
+      "Read(~/.ssh/**)",
+      "Read(~/.docker/**)"
     ]
   }
 }


### PR DESCRIPTION
- Create Dockerfile with zsh, starship, Claude Code plugins, and dev tools
- Add devbox-apple script for container lifecycle management (enter, stop, destroy, build)
- Include ccm script for Claude-powered commit message generation
- Add entrypoint script with tmp file cleanup for disk management
- Document setup, usage, port forwarding, and directory mounts in README
- Add Claude Code permission denials for .env and .ssh files in alapenna-ghostty
- Remove todo helper function from alapenna-ghostty toolkit